### PR TITLE
Remove Angular 1 from description and minor tweaks

### DIFF
--- a/i18n/2018/categories/angular/en.md
+++ b/i18n/2018/categories/angular/en.md
@@ -5,10 +5,8 @@ Not one but two major upgrades in the Angular ecosystem in 2018!
 As a consequence, the trendiest project of the Angular ecosystem was {angular-cli} the official command line tool used to scaffold new projects and manage existing projects.
 
 Among the new features, the `update` command makes it easy to update an application and its dependencies.
-Also, it's possible to customize the underlying {webpack} configuration without "ejecting".
+Also, it's now possible to customize the underlying {webpack} configuration without "ejecting".
 
 [Angular version 7](https://blog.angular.io/version-7-of-angular-cli-prompts-virtual-scroll-drag-and-drop-and-more-c594e22e7b8c) was announced in October. 
 
-It includes a major upgrade of {material-design-for-angular} and focuses on performance improvements, with a feature called "Virtual Scrolling".
-
-It's worth mentioning that {angular-1} was still trendy in 2018 (project number 15 overall).
+It includes {angular-cli} prompts, an upgrade of {material-design-for-angular}, and focuses on performance improvements, with a feature called "Virtual Scrolling".


### PR DESCRIPTION
I gave it a crack. Not sure if it's any better though 😛.

I re-read the Angular 7 release notes and realised that:

>Material Design received a big update in 2018

But:

>Angular Material users updating to v7 should expect **minor** visual differences

So the changes to Angular Material were minor, whereas the whole Material Design website had a big update.

Related issue #32