### PR TITLE
Add comments for Learning Resources category

### DIFF
--- a/i18n/2018/categories/learning/en.md
+++ b/i18n/2018/categories/learning/en.md
@@ -1,1 +1,7 @@
-Your thoughts, Angelo? :)
+As JavaScript continues to rise in popularity, so do many learning resources that aim to help developers master the language and its complex ecosystem.
+
+The top learning resources of 2018 fall roughly into two categories: Tutorials & Cheatsheets and Guidelines & Best Practices.
+
+The former consists of projects such as [30 seconds of code](https://30secondsofcode.org/), [You Don't know JS](https://github.com/getify/You-Dont-Know-JS) and [JS Algorithms & Data Structures](https://github.com/trekhleb/javascript-algorithms). These projects provide free high-quality learning resources that explain both programming concepts and some of JavaScript's particular nuances by example, allowing developers to write usable code while slowly gaining an understanding of the JavaScript ecosystem.
+
+The latter consists of projects such as [Airbnb Style Guide](https://github.com/airbnb/javascript), [Node.js Best Practices](https://github.com/i0natan/nodebestpractices) and [Front-End Checklist](https://frontendchecklist.io/). Resources like these help teams of developers maintain JavaScript projects while keeping their code style consistent and ensuring that their codebases are easy to understand, which in turn allows new contributors to join these communities and help them grow.


### PR DESCRIPTION
Based on [this discussion](https://github.com/bestofjs/bestofjs-webui/issues/68), I went ahead and added comments for the Learning Resources category.

Still missing the little card with my information (similar to the one you had last year for Evan You), not sure how to add this.