### PR TITLE
fix: add cypress to testing frameworks

### DIFF
--- a/data/2019/projects.json
+++ b/data/2019/projects.json
@@ -1060,7 +1060,7 @@
         537,
         380
       ],
-      "tags": ["test", "auto"],
+      "tags": ["test-framework", "test", "auto"],
       "owner_id": 8908513,
       "created_at": "2015-03-04T00:46:28.000Z",
       "url": "https://www.cypress.io",


### PR DESCRIPTION
Cypress is `#1` in testing frameworks if it has the correct tag, assuming that category should include e2e as well as unit test frameworks.