### PR TITLE
Try GoatCounter analytics service

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -24,6 +24,11 @@ export default class Document extends NextDocument {
             href="https://fonts.googleapis.com/css?family=Space+Mono:400,400i|Roboto+Slab:300,400,700"
             rel="stylesheet"
           />
+          <script
+            data-goatcounter="https://risingstars.goatcounter.com/count"
+            async
+            src="//gc.zgo.at/count.js"
+          ></script>
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
It would nice to be able to visualize the number of visits, using a light analytics solution that respects the privacy of users.

I've found 2 free and open-source solutions we could try:

- GoatCounter: https://www.goatcounter.com/ 
- Counder.dev https://counter.dev/

GoatCounter seems to have some traction even if the design can seem a bit old-fashioned but we don't need anything really fancy, so I'd like to try it.

An other good point: we can make the dashboard public: https://risingstars.goatcounter.com/