### PR TITLE
Update page title

### DIFF
--- a/i18n/messages/2021/en.json
+++ b/i18n/messages/2021/en.json
@@ -1,7 +1,7 @@
 {
   "page": {
     "title": "2021 JavaScript Rising Stars",
-    "description": "A complete overview of the JavaScript landscape in 2021: trends about front-end and Node.js frameworks, React and Vue.js ecosystems, building tools, state management..."
+    "description": "A complete overview of the JavaScript landscape in 2021: trends about front-end and Node.js frameworks, React and Vue.js ecosystems, build tools, state management..."
   },
   "header": {
     "title": "2021 JavaScript Rising Stars"


### PR DESCRIPTION
Noticed a typo in the title. 

Alternatively, you could change the title to match the repo description. `An overview of the JavaScript landscape in 2021: trends about front-end and Node.js frameworks, tooling, testing, Vue, React... `

Either seems mine to me.