### PR TITLE
Adjust quotes in Japanese translation 2021

### DIFF
--- a/i18n/md/collections/2021/ja/categories/all.md
+++ b/i18n/md/collections/2021/ja/categories/all.md
@@ -28,7 +28,7 @@ JavaScriptやTypeScriptでシンプルなコマンドラインスクリプトを
 5位に入った{tauri}は、Web技術を用いてデスクトップアプリケーションを構築するソリューションです。
 
 {electron}と比べると、Rustで書かれており、実行環境にNode.jsが必要ないのが特徴です。
-5月にバージョン1.0のベータ版が[リリースされました](https://dev.to/tauri/announcing-tauri-beta-more-efficient-crossplatform-apps-with-better-features-1nbd)。
+5月にバージョン1.0の[ベータ版がリリースされました](https://dev.to/tauri/announcing-tauri-beta-more-efficient-crossplatform-apps-with-better-features-1nbd)。
 
 ### ピックアップ
 

--- a/i18n/md/collections/2021/ja/categories/build.md
+++ b/i18n/md/collections/2021/ja/categories/build.md
@@ -7,20 +7,20 @@ language: ja
 
 ネイティブES modulesの採用が続き、{vite}は広く受け入れられました。
 一方Node.jsエコシステムにおいても{vitest}のようなES modulesフレームワークが作られつつありますが、こちらは一筋縄ではいきません。
-TypeScriptに至ってはES modules対応を[延期した](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#esm-nodejs)ほどです。
+TypeScriptに至っては[ES modules対応を延期した](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#esm-nodejs)ほどです。
 
 JavaScript以外の言語で作られたフロントエンドツールが[増えつつあります](https://github.com/RobinCsl/awesome-js-tooling-not-in-js)が、これは主にパフォーマンスの理由からです。
 
 Lee Robinsonが[RustはJavaScriptインフラの未来だ](https://leerob.io/blog/rust)という記事を書いています。
 Rustの興味深い点は、その素晴らしいパフォーマンスと、JavaScriptとの親和性の良さです。
-[NAPI-RS](https://napi.rs/)はシリアライズ無しにJavaScriptとRust間の通信を行うことを可能とし、Next.jsはSWCに[その将来を賭けました](https://nextjs.org/blog/next-12#faster-builds-and-fast-refresh-with-rust-compiler)。
+[NAPI-RS](https://napi.rs/)はシリアライズ無しにJavaScriptとRust間の通信を行うことを可能とし、Next.jsは[SWCにその将来を賭けました](https://nextjs.org/blog/next-12#faster-builds-and-fast-refresh-with-rust-compiler)。
 
 {parcel}2は[Rustコンパイラをひっさげて登場](https://parceljs.org/blog/v2/)しました。
-{rome}も[全面的にRustに移行する](https://rome.tools/blog/2021/09/21/rome-will-be-rewritten-in-rust)ということでしたが、創業者のひとりであるJamie Kyleは何の情報もないまま[会社を離れました](https://twitter.com/buildsghost/status/1471523960479121408)。
+{rome}も[全面的にRustに移行する](https://rome.tools/blog/2021/09/21/rome-will-be-rewritten-in-rust)ということでしたが、創業者のひとりである[Jamie Kyleは何の情報もないまま会社を離れました](https://twitter.com/buildsghost/status/1471523960479121408)。
 
 Rustは非JS言語の代表格ですが、決して唯一ではありません。
 素晴らしいパフォーマンスを発揮する言語は他にもあり、[Bun](http://bun.sh/)はZigで書かれており、{turborepo}や{esbuild}はGo製です。
-そういえばEvan Wallaceが[Figmaを去った](https://twitter.com/buildsghost/status/1471523960479121408)のは、esbuildの開発に時間を割けるようになったからかもしれません。
+そういえば[Evan WallaceがFigmaを去った](https://twitter.com/buildsghost/status/1471523960479121408)のは、esbuildの開発に時間を割けるようになったからかもしれません。
 
 monorepo分野では[Lerna](https://github.com/lerna/lerna)が最も使われていますが、既にあまり保守されていません。
 次を狙って、ビルド時間を大幅に短縮できるモノレポツール [Nx](https://nx.dev/)が[急成長しています](https://twitter.com/victorsavkin/status/1476618225551036427)。

--- a/i18n/md/collections/2021/ja/categories/react.md
+++ b/i18n/md/collections/2021/ja/categories/react.md
@@ -4,10 +4,10 @@ language: ja
 ---
 
 まもなくReact18がリリースされます。
-既にRC版を触ることは可能で、[Automatic Batching](https://github.com/reactwg/react-18/discussions/21)によるレンダリング削減や、[SSRのSuspenseサポート](https://github.com/reactwg/react-18/discussions/22)など、すぐに利用できる改善がいくつもあります。
+既に[RC版](https://github.com/reactwg/react-18/discussions/9)を触ることは可能で、[Automatic Batchingによるレンダリング削減](https://github.com/reactwg/react-18/discussions/21)や、[SSRのSuspenseサポート](https://github.com/reactwg/react-18/discussions/22)など、すぐに利用できる改善がいくつもあります。
 
 React18は待望のConcurrent Renderingが実装され、大きな破壊的変更なしに[Suspense](https://github.com/reactwg/react-18/discussions/47#discussioncomment-847004)が刷新されました。
-[startTransition](https://github.com/reactwg/react-18/discussions/41)など一部の機能は`18.0`リリース当初から使用可能になる予定です。
+[startTransition](https://github.com/reactwg/react-18/discussions/41)など一部の機能は18.0リリース当初から使用可能になる予定です。
 しかし、[昨年のRising Star](https://risingstars.js.org/2020/en#section-react)で紹介した[Server Components](https://reactjs.org/blog/2020/12/21/data-fetching-with-react-server-components.html)等については、もう少し待つ必要がありそうです。
 
 Reactはブラウザでもサーバでも進化を続けており、[React Nativeのプラットフォーム構想](https://reactnative.dev/blog/2021/08/26/many-platform-vision)も進行中で、ますますユビキタスな存在になろうとしています。


### PR DESCRIPTION
- Based on PR #93 (Japanese translation 2021 #93)
- Adjust a tag quotes
- Add a link on `RC版` ( `RC version` )

```
- 総合ランキング Most Popular Projects Overall
  - before: リリースされました
  - after: ベータ版がリリースされました
- ビルドツール Build Tools
  - before: 延期した
  - after:  ES modules対応を延期した
  - before: その将来を賭けました
  - after:  SWCにその将来を賭けました
  - before: 会社を離れました
  - after:  Jamie Kyleは何の情報もないまま会社を離れました
  - before: Evan WallaceがFigmaを去った
  - after:  Figmaを去った
- React エコシステム React Ecosystem
  - before: Missing link to https://github.com/reactwg/react-18/discussions/9
  - after:  [RC版](https://github.com/reactwg/react-18/discussions/9)
  - before: Automatic Batching
  - after:  Automatic Batchingによるレンダリング削減
  - before: `18.0`
  - after: 18.0
```