### PR TITLE
Fix language mobile menu on mobile and improvements for performance

### DIFF
--- a/src/components/category.tsx
+++ b/src/components/category.tsx
@@ -34,28 +34,24 @@ export const Category = ({
           </span>
         </h2>
         <div className={`${hasComment ? "project-category-grid" : ""}`}>
-          <div>
-            <div className={`${hasComment ? "column1" : ""}`}>
-              <ProjectList
-                count={count}
-                limit={limit || 5}
-                tagKey={key}
-                tags={tags}
-                projects={graphProjects}
-                year={year}
-              />
-            </div>
+          <div className={`${hasComment ? "column1" : ""}`}>
+            <ProjectList
+              count={count}
+              limit={limit || 5}
+              tagKey={key}
+              tags={tags}
+              projects={graphProjects}
+              year={year}
+            />
           </div>
-          <div>
-            {hasComment && (
-              <div className="column2">
-                <div className="tag-card-comments markdown-body">
-                  {guest && <Guest guestId={guest} />}
-                  <TranslatedBlock path={tag} />
-                </div>
+          {hasComment && (
+            <div className="column2">
+              <div className="tag-card-comments markdown-body">
+                {guest && <Guest guestId={guest} />}
+                <TranslatedBlock path={tag} />
               </div>
-            )}
-          </div>
+            </div>
+          )}
         </div>
       </div>
     </section>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -14,7 +14,7 @@ export const Footer = () => (
           href="https://vercel.com?utm_source=bestofjs"
           className={styles.poweredByLogo}
         >
-          <img width="80" src="/vercel.svg" alt="Vercel" />
+          <img width="80" height="19" src="/vercel.svg" alt="Vercel" />
         </a>
       </p>
     </div>

--- a/src/components/guest.tsx
+++ b/src/components/guest.tsx
@@ -1,3 +1,5 @@
+import Image from 'next/image';
+
 import { TranslatedBlock } from "components/translated-block";
 
 export const Guest = ({ guestId }: {guestId: string}) => (
@@ -6,7 +8,7 @@ export const Guest = ({ guestId }: {guestId: string}) => (
       <TranslatedBlock path={guestId} />
     </div>
     <div className="guest-portrait">
-      <img
+      <Image
         src={`/img/guests/${guestId}.jpg`}
         width="120"
         height="120"

--- a/src/components/guest.tsx
+++ b/src/components/guest.tsx
@@ -1,12 +1,17 @@
 import { TranslatedBlock } from "components/translated-block";
 
-export const Guest = ({ guestId }) => (
+export const Guest = ({ guestId }: {guestId: string}) => (
   <div className="guest">
     <div className="guest-blurb">
       <TranslatedBlock path={guestId} />
     </div>
     <div className="guest-portrait">
-      <img src={`/img/guests/${guestId}.jpg`} />
+      <img
+        src={`/img/guests/${guestId}.jpg`}
+        width="120"
+        height="120"
+        alt={`Guest Writer ${guestId}`}
+      />
     </div>
   </div>
 );

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -15,6 +15,7 @@ export const Header = ({ language, year, availableLanguages }: Props) => {
             <img
               src={"https://bestofjs.org/svg/bestofjs.svg"}
               width="130"
+              height="37.14"
               alt="Best of JS logo"
             />
           </a>

--- a/src/components/header/language-menu-compact.tsx
+++ b/src/components/header/language-menu-compact.tsx
@@ -34,7 +34,7 @@ export const LanguageMenuCompact = ({
           </select>
         </div>
         <div className="icon is-left">
-          <img src="/globe.svg" width="24" height="24" />
+          <img src="/globe.svg" width="24" height="24" alt="language" />
         </div>
       </div>
     </div>

--- a/src/components/header/language-menu-compact.tsx
+++ b/src/components/header/language-menu-compact.tsx
@@ -14,8 +14,8 @@ export const LanguageMenuCompact = ({
   languages,
 }: Props) => {
   const router = useRouter();
-  const onChange = (e) => {
-    const path = e.target.value;
+  const onChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const path = event.target.value;
     router.push(path);
   };
 
@@ -26,10 +26,10 @@ export const LanguageMenuCompact = ({
           <select
             className="language-dropdown"
             onChange={onChange}
-            value={currentLanguage}
+            value={getPath(year, currentLanguage)}
           >
             {languages.map((item) => (
-              <LanguageLink item={item} key={item.code} year={year} />
+              <LanguageOption item={item} key={item.code} year={year} />
             ))}
           </select>
         </div>
@@ -41,6 +41,16 @@ export const LanguageMenuCompact = ({
   );
 };
 
-const LanguageLink = ({ item, year }) => {
-  return <option value={`/${year}/${item.code}`}>{item.text}</option>;
+const LanguageOption = ({
+  item,
+  year,
+}: {
+  item: RisingStars.Language;
+  year: number;
+}) => {
+  return <option value={getPath(year, item.code)}>{item.text}</option>;
 };
+
+function getPath(year: number, language: string) {
+  return `/${year}/${language}`;
+}

--- a/src/components/project-list/project-chart.tsx
+++ b/src/components/project-list/project-chart.tsx
@@ -40,7 +40,7 @@ export const ProjectChart = ({ project }: Props) => {
                   }}
                 >
                   <div className="project-chart-stars">
-                    {d > 0 && <span>{formatStarNumber(d, 1)}</span>}
+                    {d > 0 && <>{formatStarNumber(d, 1)}</>}
                   </div>
                 </div>
               ) : (

--- a/src/components/project-list/project-list.tsx
+++ b/src/components/project-list/project-list.tsx
@@ -57,7 +57,7 @@ const ProjectListItem = ({ maxDelta, project, tags, tagKey, year, index }) => {
   // only first project of "all" category should start expanded
   const defaultIsOpen = tagKey === "all" && index === 1;
   const [isOpen, setIsOpen] = useState(defaultIsOpen);
-  const widthPercent = (project.delta * 100) / maxDelta; // use relative scale
+  const widthPercent = Math.ceil((project.delta * 100) / maxDelta); // use relative scale
   return (
     <div>
       <ProjectSummary
@@ -67,7 +67,12 @@ const ProjectListItem = ({ maxDelta, project, tags, tagKey, year, index }) => {
         project={project}
         index={index}
       />
-      <ProjectDetails isOpen={isOpen} project={project} tags={tags} year={year} />
+      <ProjectDetails
+        isOpen={isOpen}
+        project={project}
+        tags={tags}
+        year={year}
+      />
     </div>
   );
 };

--- a/src/components/project-list/project-summary.tsx
+++ b/src/components/project-list/project-summary.tsx
@@ -22,9 +22,7 @@ export const ProjectSummary = ({
         setIsOpen(!isOpen);
       }}
     >
-      <div className="ranking">
-        <span>{index}</span>
-      </div>
+      <div className="ranking">{index}</div>
       <div className="inner">
         <div className="icon">
           <ProjectAvatar project={project} size={50} />
@@ -35,27 +33,10 @@ export const ProjectSummary = ({
             style={{ width: `${widthPercent}%` }}
           />
           <h4 className="project-name">{project.name}</h4>
-          <div className="description">
-            <Description text={project.description} showEmojis={false} />
-          </div>
+          <div className="description">{project.description}</div>
         </div>
         <div className="stars">+{formatStarNumber(project.delta, 1)}☆</div>
       </div>
     </div>
   );
-};
-
-// Component used to display repository `description`,
-// removing emojis except if `showEmojis` option is set to true
-// See node.js repository: `Node.js JavaScript runtime :sparkles::turtle::rocket::sparkles:`
-const Description = ({ text, showEmojis }) => {
-  const replacedBy = showEmojis ? emoji() : "";
-  const result = text.replace(/(:([a-z_\d]+):)/g, replacedBy).trim();
-  if (showEmojis) return <span dangerouslySetInnerHTML={{ __html: result }} />;
-  return <span>{result}</span>;
-};
-
-const emoji = () => {
-  const size = 20;
-  return `<img align="absmiddle" width="${size}" height=${size} src="https://assets-cdn.github.com/images/icons/emoji/$2.png">`;
 };

--- a/src/components/top/top.tsx
+++ b/src/components/top/top.tsx
@@ -20,30 +20,60 @@ export const Top = ({ allYears, year }: Props) => {
 };
 
 const YearNavigator = ({ allYears, year: activeYear }: Props) => {
+  const hasPreviousYear = activeYear !== allYears[0];
+  const hasNextYear = activeYear !== allYears[allYears.length - 1];
+
   return (
     <div className="year-menu-container">
       <div className="container small-container">
         <div className="year-menu">
-          {allYears.map((year) => (
-            <YearLink key={year} year={year} isActive={activeYear === year} />
-          ))}
+          {hasPreviousYear && (
+            <YearLink year={activeYear - 1} className="mobile-link">
+              &larr;&nbsp;
+              {activeYear - 1}
+            </YearLink>
+          )}
+          {allYears.map((year) =>
+            activeYear === year ? (
+              <div key={year} className="active">
+                {year}
+              </div>
+            ) : (
+              <YearLink key={year} year={year} className="desktop-link">
+                {abbreviateYear(year)}
+              </YearLink>
+            )
+          )}
+          {hasNextYear && (
+            <YearLink year={activeYear + 1} className="mobile-link">
+              {activeYear + 1}
+              &nbsp;&rarr;
+            </YearLink>
+          )}
         </div>
       </div>
     </div>
   );
 };
 
-const YearLink = ({ year, isActive }) => {
-  return isActive ? (
-    <div className="active">{year}</div>
-  ) : (
+const YearLink = ({
+  year,
+  children,
+  className,
+}: {
+  year: number;
+  children: React.ReactNode;
+  className?: string;
+}) => {
+  return (
     <Link
       href={{
         pathname: "/[year]/[language]",
         query: { year, language: "en" },
       }}
+      className={className}
     >
-      {abbreviateYear(year)}
+      {children}
     </Link>
   );
 };

--- a/src/components/translator-section.tsx
+++ b/src/components/translator-section.tsx
@@ -109,7 +109,7 @@ const TranslatorBlock = ({ translators, language }) => (
 
 const TeamMember = ({ member }) => (
   <div className="translator-list-item">
-    <a href={member.url}>
+    <a href={member.url} aria-label={member.name}>
       <img className="avatar" src={member.avatar} width="75" height="75" />
     </a>
     <div className="translator-item-body">

--- a/src/components/translator-section.tsx
+++ b/src/components/translator-section.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import Link from "next/link";
 
 import {
@@ -110,7 +111,7 @@ const TranslatorBlock = ({ translators, language }) => (
 const TeamMember = ({ member }) => (
   <div className="translator-list-item">
     <a href={member.url} aria-label={member.name}>
-      <img className="avatar" src={member.avatar} width="75" height="75" />
+      <Image className="avatar" src={member.avatar} width="75" height="75" />
     </a>
     <div className="translator-item-body">
       <a href={member.url} className="translator-name">

--- a/src/components/translator-section.tsx
+++ b/src/components/translator-section.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import Link from "next/link";
 
 import {
@@ -111,7 +110,7 @@ const TranslatorBlock = ({ translators, language }) => (
 const TeamMember = ({ member }) => (
   <div className="translator-list-item">
     <a href={member.url} aria-label={member.name}>
-      <Image className="avatar" src={member.avatar} width="75" height="75" />
+      <img className="avatar" src={member.avatar} width="75" height="75" />
     </a>
     <div className="translator-item-body">
       <a href={member.url} className="translator-name">

--- a/src/components/translator-section.tsx
+++ b/src/components/translator-section.tsx
@@ -110,7 +110,7 @@ const TranslatorBlock = ({ translators, language }) => (
 const TeamMember = ({ member }) => (
   <div className="translator-list-item">
     <a href={member.url} aria-label={member.name}>
-      <img className="avatar" src={member.avatar} width="75" height="75" />
+      <img className="avatar" src={member.avatar} width="75" height="75" alt={member.name} />
     </a>
     <div className="translator-item-body">
       <a href={member.url} className="translator-name">

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -2,7 +2,7 @@
   --spacing: 20px;
 
   --orange: #cc4700;
-  --linkColor: var(--orange);
+  --linkColor: #c2410c;
   --activeLinkColor: #e65000;
 
   --red: #e60932;
@@ -24,7 +24,7 @@
   --lightest-text-color: var(--grey3);
   --light-border-color: var(--grey3);
   --border-color: var(--mediumgrey);
-  --bg-color: #edefed;
+  --bg-color: #f2f2f0;
   --chart-bar-bg-color: rgba(228, 91, 18, 0.15);
 
   --root-size-mobile: 15px;
@@ -254,6 +254,7 @@ h1 {
 
 hr {
   border-top-width: 0;
+  border-color: var(--border-color);
 }
 
 code {

--- a/src/css/top.css
+++ b/src/css/top.css
@@ -12,3 +12,16 @@
   background-color: #e65000;
   color: white;
 }
+
+/* Don't show all years on small screens */
+@media (max-width: 599px) {
+  .year-menu > .desktop-link {
+    display: none;
+  }
+}
+
+@media (min-width: 600px) {
+  .year-menu > .mobile-link {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Goal

- Fix language menu on mobile (#111 )
- Improve the menu to switch the year on mobile, showing only the current, the previous, and the next year
- Improve performance by using Next Image component for some Guest Writer's avatars
- Reduce the number of DOM elements: from `7,772` to `6,773`
- Improve accessibility score by adding missing attributes on images and increasing the contrast of links

## Lighthouse score on the branch

![image](https://user-images.githubusercontent.com/5546996/211152643-d9567ed9-8e6f-455d-ad67-c55efa85e69e.png)


## Screenshots

![image](https://user-images.githubusercontent.com/5546996/211152801-9bea6d70-89db-4473-846a-116b727dcd1b.png)

![image](https://user-images.githubusercontent.com/5546996/211152809-e4416b83-cc01-4fcc-a3ce-5c4b7c35f0a7.png)

