### PR TITLE
Reduce the amount of HTML

### DIFF
--- a/src/components/category.tsx
+++ b/src/components/category.tsx
@@ -19,7 +19,7 @@ export const Category = ({
   const { availableComments, key: tag, limit, count, guest } = category;
 
   if (!projects) throw new Error(`No projects with the tag "${tag}"`);
-  const graphProjects = projects.slice(0, count);
+  const visibleProjects = projects.slice(0, count);
   const key = tag.replace(/-/gi, "");
 
   const hasComment = !availableComments || availableComments.includes(language);
@@ -37,10 +37,10 @@ export const Category = ({
           <div className={`${hasComment ? "column1" : ""}`}>
             <ProjectList
               count={count}
+              isFirstItemOpenByDefault={key === "all"}
               limit={limit || 5}
-              tagKey={key}
+              projects={visibleProjects}
               tags={tags}
-              projects={graphProjects}
               year={year}
             />
           </div>

--- a/src/components/project-list/project-details.tsx
+++ b/src/components/project-list/project-details.tsx
@@ -7,12 +7,11 @@ type Props = {
   project: RisingStars.Project;
   tags: RisingStars.Tag[];
   year: number;
-  isOpen: boolean;
 };
-export const ProjectDetails = ({ project, isOpen, tags, year }: Props) => {
+export const ProjectDetails = ({ project, tags, year }: Props) => {
   const { url, full_name, repository, stars } = project;
   return (
-    <div className={`project-details ${isOpen ? "is-open" : "is-closed"}`}>
+    <div className="project-details">
       <div className="project-details-inner">
         <Heading>
           <FormattedMessage

--- a/src/components/project-list/project-list.tsx
+++ b/src/components/project-list/project-list.tsx
@@ -4,18 +4,19 @@ import { ProjectSummary } from "./project-summary";
 import { ProjectDetails } from "./project-details";
 
 type Props = {
-  year: number;
-  tagKey: string;
-  tags: RisingStars.Tag[];
-  projects: RisingStars.Project[];
-  limit: number;
   count: number;
+  isFirstItemOpenByDefault: boolean;
+  limit: number;
+  projects: RisingStars.Project[];
+  tags: RisingStars.Tag[];
+  year: number;
 };
+
 export const ProjectList = ({
-  projects,
-  limit = 5,
   count,
-  tagKey,
+  limit = 5,
+  projects,
+  isFirstItemOpenByDefault,
   tags,
   year,
 }: Props) => {
@@ -30,10 +31,10 @@ export const ProjectList = ({
         {visibleProjects.map((project, i) => (
           <ProjectListItem
             key={project.slug}
-            tags={tags}
-            tagKey={tagKey}
-            maxDelta={maxDelta}
             project={project}
+            tags={tags}
+            defaultIsOpen={i === 0 && isFirstItemOpenByDefault}
+            maxDelta={maxDelta}
             year={year}
             index={i + 1}
           />
@@ -53,19 +54,31 @@ export const ProjectList = ({
   );
 };
 
-const ProjectListItem = ({ maxDelta, project, tags, tagKey, year, index }) => {
-  // only first project of "all" category should start expanded
-  const defaultIsOpen = tagKey === "all" && index === 1;
+type ListItemProps = {
+  index: number;
+  defaultIsOpen: boolean;
+  maxDelta: number;
+  project: RisingStars.Project;
+} & Pick<Props, "tags" | "year">;
+
+const ProjectListItem = ({
+  index,
+  defaultIsOpen,
+  maxDelta,
+  project,
+  tags,
+  year,
+}: ListItemProps) => {
   const [isOpen, setIsOpen] = useState(defaultIsOpen);
   const widthPercent = Math.ceil((project.delta * 100) / maxDelta); // use relative scale
   return (
     <div>
       <ProjectSummary
-        widthPercent={widthPercent}
-        setIsOpen={setIsOpen}
+        index={index}
         isOpen={isOpen}
         project={project}
-        index={index}
+        setIsOpen={setIsOpen}
+        widthPercent={widthPercent}
       />
       {isOpen && <ProjectDetails project={project} tags={tags} year={year} />}
     </div>

--- a/src/components/project-list/project-list.tsx
+++ b/src/components/project-list/project-list.tsx
@@ -67,12 +67,7 @@ const ProjectListItem = ({ maxDelta, project, tags, tagKey, year, index }) => {
         project={project}
         index={index}
       />
-      <ProjectDetails
-        isOpen={isOpen}
-        project={project}
-        tags={tags}
-        year={year}
-      />
+      {isOpen && <ProjectDetails project={project} tags={tags} year={year} />}
     </div>
   );
 };

--- a/src/css/project-details.css
+++ b/src/css/project-details.css
@@ -2,7 +2,7 @@
   background: white;
   z-index: 100;
   overflow: hidden;
-  display: none;
+  /* display: none; */
 }
 .project-details.is-open {
   opacity: 1;

--- a/src/css/project-details.css
+++ b/src/css/project-details.css
@@ -2,12 +2,6 @@
   background: white;
   z-index: 100;
   overflow: hidden;
-  /* display: none; */
-}
-.project-details.is-open {
-  opacity: 1;
-  z-index: 20;
-  display: block;
 }
 
 .project-details-inner {


### PR DESCRIPTION
## Goal

We send way too much HTML data: `435 kB` for the English page, +6700 DOM elements

The main problem is that the project details section, that includes the graph of the monthly trends, is hidden by CSS.

So basically the HTML page includes the graph of all projects mentioned in the rankings, even if you have to click on the project rows to see the details 🙀 !

By removing from the component tree, the size of page drops to `188 kB` (1400 DOM elements)

## Lighthouse score on the branch

![image](https://user-images.githubusercontent.com/5546996/211227633-fd166f64-630c-4b30-9d52-7e111d9a72a6.png)
