### PR TITLE
Hide "SHOW MORE" button if top list contains less projects than limit

### DIFF
--- a/src/components/category.astro
+++ b/src/components/category.astro
@@ -43,18 +43,22 @@ const hasComment = !availableComments || availableComments.includes(language);
           starDeltaReference={projects[0].delta}
         />
 
-        <button
-          type="button"
-          class="button show-more-button"
-          hx-get={`/${year}/${language}/${tag}`}
-          hx-select=".extra-projects"
-          hx-trigger="click"
-          hx-target="this"
-          hx-swap="outerHTML"
-        >
-          SHOW MORE
-          <LoadingIndicator />
-        </button>
+        {
+          topProjects.length > limit && (
+            <button
+              type="button"
+              class="button show-more-button"
+              hx-get={`/${year}/${language}/${tag}`}
+              hx-select=".extra-projects"
+              hx-trigger="click"
+              hx-target="this"
+              hx-swap="outerHTML"
+            >
+              SHOW MORE
+              <LoadingIndicator />
+            </button>
+          )
+        }
       </div>
       {
         hasComment && (

--- a/src/components/category.astro
+++ b/src/components/category.astro
@@ -44,7 +44,7 @@ const hasComment = !availableComments || availableComments.includes(language);
         />
 
         {
-          topProjects.length > limit && (
+          projects.length > limit && (
             <button
               type="button"
               class="button show-more-button"


### PR DESCRIPTION
For example the desktop category only has 5 entries and displays "SHOW MORE" button implying there are more entries in the list (which is not the case)

<img width="708" alt="Screenshot 2024-02-14 at 16 10 00" src="https://github.com/bestofjs/javascript-risingstars/assets/10400064/35e70017-84db-41d2-8613-99fc02603953">
