### PR TITLE
Add missing project icons

### DIFF
--- a/data/2016/projects.json
+++ b/data/2016/projects.json
@@ -2,6 +2,7 @@
   "projects": [
     {
       "name": "Vue.js",
+      "slug": "vuejs",
       "full_name": "vuejs/vue",
       "description": "🖖 A progressive, incrementally-adoptable JavaScript framework for building UI on the web.",
       "stars": 79318,
@@ -13,11 +14,11 @@
       "owner_id": 6128107,
       "icon": "vue.svg",
       "created_at": "2013-07-29T03:24:51.000Z",
-      "url": "http://vuejs.org",
-      "slug": "vuejs"
+      "url": "http://vuejs.org"
     },
     {
       "name": "React",
+      "slug": "react",
       "full_name": "facebook/react",
       "description": "A declarative, efficient, and flexible JavaScript library for building user interfaces.",
       "stars": 85350,
@@ -29,11 +30,11 @@
       "owner_id": 69631,
       "icon": "react.svg",
       "created_at": "2013-05-24T16:15:54.000Z",
-      "url": "https://reactjs.org",
-      "slug": "react"
+      "url": "https://reactjs.org"
     },
     {
       "name": "Electron",
+      "slug": "electron",
       "full_name": "electron/electron",
       "description": "Build cross platform desktop apps with JavaScript, HTML, and CSS",
       "stars": 55064,
@@ -45,11 +46,11 @@
       "owner_id": 13409222,
       "icon": "electron.svg",
       "created_at": "2013-04-12T01:47:36.000Z",
-      "url": "https://electronjs.org",
-      "slug": "electron"
+      "url": "https://electronjs.org"
     },
     {
       "name": "React Native",
+      "slug": "react-native",
       "full_name": "facebook/react-native",
       "description": "A framework for building native apps with React.",
       "stars": 58274,
@@ -61,11 +62,11 @@
       "owner_id": 69631,
       "icon": "react-native.svg",
       "created_at": "2015-01-09T18:10:16.000Z",
-      "url": "http://facebook.github.io/react-native/",
-      "slug": "react-native"
+      "url": "http://facebook.github.io/react-native/"
     },
     {
       "name": "Redux",
+      "slug": "redux",
       "full_name": "reactjs/redux",
       "description": "Predictable state container for JavaScript apps",
       "stars": 37158,
@@ -77,11 +78,11 @@
       "owner_id": 6412038,
       "icon": "redux.svg",
       "created_at": "2015-05-29T23:53:15.000Z",
-      "url": "http://redux.js.org",
-      "slug": "redux"
+      "url": "http://redux.js.org"
     },
     {
       "name": "Bootstrap",
+      "slug": "bootstrap",
       "full_name": "twbs/bootstrap",
       "description": "The most popular HTML, CSS, and JavaScript framework for developing responsive, mobile first project",
       "stars": 120175,
@@ -93,11 +94,11 @@
       "owner_id": 2918581,
       "icon": "bootstrap.svg",
       "created_at": "2011-07-29T21:19:00.000Z",
-      "url": "http://getbootstrap.com",
-      "slug": "bootstrap"
+      "url": "http://getbootstrap.com"
     },
     {
       "name": "D3",
+      "slug": "d3",
       "full_name": "d3/d3",
       "description": "Bring data to life with SVG, Canvas and HTML. :bar_chart::chart_with_upwards_trend::tada:",
       "stars": 71527,
@@ -109,10 +110,11 @@
       "owner_id": 1562726,
       "created_at": "2010-09-27T17:22:42.000Z",
       "url": "https://d3js.org",
-      "slug": "d3"
+      "icon": "d3.svg"
     },
     {
       "name": "VS Code",
+      "slug": "vs-code",
       "full_name": "Microsoft/vscode",
       "description": "Visual Studio Code",
       "stars": 41758,
@@ -124,11 +126,11 @@
       "owner_id": 6154722,
       "icon": "vscode.svg",
       "created_at": "2015-09-03T20:23:38.000Z",
-      "url": "https://code.visualstudio.com",
-      "slug": "vs-code"
+      "url": "https://code.visualstudio.com"
     },
     {
       "name": "Node.js",
+      "slug": "nodejs",
       "full_name": "nodejs/node",
       "description": "Node.js JavaScript runtime :sparkles::turtle::rocket::sparkles:",
       "stars": 44280,
@@ -140,10 +142,11 @@
       "owner_id": 9950313,
       "created_at": "2014-11-26T19:57:11.000Z",
       "url": "https://nodejs.org",
-      "slug": "nodejs"
+      "icon": "nodejs.svg"
     },
     {
       "name": "Webpack",
+      "slug": "webpack",
       "full_name": "webpack/webpack",
       "description": "A bundler for javascript and friends. Packs many modules into a few bundled assets. Code Splitting a",
       "stars": 35713,
@@ -155,11 +158,11 @@
       "owner_id": 2105791,
       "icon": "webpack.svg",
       "created_at": "2012-03-10T10:08:14.000Z",
-      "url": "https://webpack.js.org",
-      "slug": "webpack"
+      "url": "https://webpack.js.org"
     },
     {
       "name": "Angular",
+      "slug": "angular",
       "full_name": "angular/angular",
       "description": "One framework. Mobile & desktop.",
       "stars": 31827,
@@ -169,10 +172,11 @@
       "owner_id": 139426,
       "created_at": "2014-09-18T16:12:01.000Z",
       "url": "https://angular.io",
-      "slug": "angular"
+      "icon": "angular.svg"
     },
     {
       "name": "Atom",
+      "slug": "atom",
       "full_name": "atom/atom",
       "description": ":atom: The hackable text editor",
       "stars": 42749,
@@ -182,11 +186,11 @@
       "owner_id": 1089146,
       "icon": "atom.svg",
       "created_at": "2012-01-20T18:18:21.000Z",
-      "url": "https://atom.io",
-      "slug": "atom"
+      "url": "https://atom.io"
     },
     {
       "name": "Create React App",
+      "slug": "create-react-app",
       "full_name": "facebookincubator/create-react-app",
       "description": "Create React apps with no build configuration.",
       "stars": 40707,
@@ -196,11 +200,11 @@
       "owner_id": 19538647,
       "icon": "cra.svg",
       "created_at": "2016-07-17T14:55:11.000Z",
-      "url": "",
-      "slug": "create-react-app"
+      "url": ""
     },
     {
       "name": "TypeScript",
+      "slug": "typescript",
       "full_name": "Microsoft/TypeScript",
       "description": "TypeScript is a superset of JavaScript that compiles to clean JavaScript output.",
       "stars": 29771,
@@ -210,11 +214,11 @@
       "owner_id": 6154722,
       "icon": "typescript.svg",
       "created_at": "2014-06-17T15:28:39.000Z",
-      "url": "http://www.typescriptlang.org",
-      "slug": "typescript"
+      "url": "http://www.typescriptlang.org"
     },
     {
       "name": "Material UI",
+      "slug": "material-ui",
       "full_name": "mui-org/material-ui",
       "description": "React components that implement Google's Material Design.",
       "stars": 32115,
@@ -224,11 +228,11 @@
       "owner_id": 33663932,
       "icon": "material-ui.svg",
       "created_at": "2014-08-18T19:11:54.000Z",
-      "url": "http://www.material-ui.com",
-      "slug": "material-ui"
+      "url": "http://www.material-ui.com"
     },
     {
       "name": "React Router",
+      "slug": "react-router",
       "full_name": "ReactTraining/react-router",
       "description": "Declarative routing for React",
       "stars": 27448,
@@ -238,10 +242,11 @@
       "owner_id": 11823761,
       "created_at": "2014-05-16T22:22:51.000Z",
       "url": "https://reacttraining.com/react-router/",
-      "slug": "react-router"
+      "icon": "react-router.svg"
     },
     {
       "name": "React boilerplate",
+      "slug": "react-boilerplate",
       "full_name": "react-boilerplate/react-boilerplate",
       "description": ":fire: A highly scalable, offline-first foundation with the best developer experience and a focus on",
       "stars": 16657,
@@ -250,11 +255,11 @@
       "tags": ["boilerplate", "react", "redux", "offline"],
       "owner_id": 25323389,
       "created_at": "2015-02-18T14:36:32.000Z",
-      "url": "https://www.reactboilerplate.com",
-      "slug": "react-boilerplate"
+      "url": "https://www.reactboilerplate.com"
     },
     {
       "name": "Angular 1",
+      "slug": "angular-1",
       "full_name": "angular/angular.js",
       "description": "AngularJS - HTML enhanced for web apps!",
       "stars": 57787,
@@ -264,11 +269,11 @@
       "owner_id": 139426,
       "icon": "angularjs.svg",
       "created_at": "2010-01-06T00:34:37.000Z",
-      "url": "https://angularjs.org",
-      "slug": "angular-1"
+      "url": "https://angularjs.org"
     },
     {
       "name": "Express",
+      "slug": "express",
       "full_name": "expressjs/express",
       "description": "Fast, unopinionated, minimalist web framework for node.",
       "stars": 36006,
@@ -278,11 +283,11 @@
       "owner_id": 5658226,
       "icon": "express.svg",
       "created_at": "2009-06-26T18:56:01.000Z",
-      "url": "https://expressjs.com",
-      "slug": "express"
+      "url": "https://expressjs.com"
     },
     {
       "name": "Inferno",
+      "slug": "inferno",
       "full_name": "infernojs/inferno",
       "description": "An extremely fast, React-like JavaScript library for building modern user interfaces",
       "stars": 12025,
@@ -292,10 +297,11 @@
       "owner_id": 14214240,
       "created_at": "2015-02-01T22:07:38.000Z",
       "url": "http://infernojs.org",
-      "slug": "inferno"
+      "icon": "inferno.svg"
     },
     {
       "name": "Babel",
+      "slug": "babel",
       "full_name": "babel/babel",
       "description": ":tropical_fish: Babel is a compiler for writing next generation JavaScript.",
       "stars": 25206,
@@ -305,10 +311,11 @@
       "owner_id": 9637642,
       "created_at": "2014-09-28T13:38:23.000Z",
       "url": "https://babeljs.io/",
-      "slug": "babel"
+      "icon": "babel.svg"
     },
     {
       "name": "React Starter Kit",
+      "slug": "react-starter-kit",
       "full_name": "kriasoft/react-starter-kit",
       "description": "React Starter Kit — isomorphic web app boilerplate (Node.js, Express, GraphQL, React.js, Babel, Post",
       "stars": 16551,
@@ -317,11 +324,11 @@
       "tags": ["react", "isomorphic", "boilerplate", "graphql"],
       "owner_id": 773036,
       "created_at": "2014-04-16T13:08:18.000Z",
-      "url": "https://reactstarter.com",
-      "slug": "react-starter-kit"
+      "url": "https://reactstarter.com"
     },
     {
       "name": "Gulp",
+      "slug": "gulp",
       "full_name": "gulpjs/gulp",
       "description": "The streaming build system",
       "stars": 28419,
@@ -331,11 +338,11 @@
       "owner_id": 6200624,
       "icon": "gulp.svg",
       "created_at": "2013-07-04T05:26:06.000Z",
-      "url": "http://gulpjs.com",
-      "slug": "gulp"
+      "url": "http://gulpjs.com"
     },
     {
       "name": "Ionic",
+      "slug": "ionic",
       "full_name": "ionic-team/ionic",
       "description": "Build amazing native and progressive web apps with open web technologies. One app running on everyth",
       "stars": 32895,
@@ -345,11 +352,11 @@
       "owner_id": 3171503,
       "icon": "ionic.svg",
       "created_at": "2013-08-20T23:06:02.000Z",
-      "url": "https://ionicframework.com/",
-      "slug": "ionic"
+      "url": "https://ionicframework.com/"
     },
     {
       "name": "Hexo",
+      "slug": "hexo",
       "full_name": "hexojs/hexo",
       "description": "A fast, simple & powerful blog framework, powered by Node.js.",
       "stars": 20089,
@@ -359,11 +366,11 @@
       "owner_id": 6375567,
       "icon": "hexo.svg",
       "created_at": "2012-09-23T15:17:08.000Z",
-      "url": "https://hexo.io",
-      "slug": "hexo"
+      "url": "https://hexo.io"
     },
     {
       "name": "AVA",
+      "slug": "ava",
       "full_name": "avajs/ava",
       "description": ":rocket: Futuristic JavaScript test runner",
       "stars": 12419,
@@ -373,10 +380,11 @@
       "owner_id": 8527916,
       "created_at": "2014-11-18T17:20:26.000Z",
       "url": "",
-      "slug": "ava"
+      "icon": "ava.svg"
     },
     {
       "name": "React Redux Universal Hot Example",
+      "slug": "react-redux-universal-hot-example",
       "full_name": "erikras/react-redux-universal-hot-example",
       "description": "A starter boilerplate for a universal webapp using express, react, redux, webpack, and react-transfo",
       "stars": 10783,
@@ -385,11 +393,11 @@
       "tags": ["boilerplate", "react", "redux"],
       "owner_id": 4396759,
       "created_at": "2015-06-23T16:39:21.000Z",
-      "url": "",
-      "slug": "react-redux-universal-hot-example"
+      "url": ""
     },
     {
       "name": "Enzyme",
+      "slug": "enzyme",
       "full_name": "airbnb/enzyme",
       "description": "JavaScript Testing utilities for React",
       "stars": 12262,
@@ -398,11 +406,11 @@
       "tags": ["test", "react"],
       "owner_id": 698437,
       "created_at": "2015-11-10T21:45:38.000Z",
-      "url": "http://airbnb.io/enzyme/",
-      "slug": "enzyme"
+      "url": "http://airbnb.io/enzyme/"
     },
     {
       "name": "Preact",
+      "slug": "preact",
       "full_name": "developit/preact",
       "description": "⚛️ Fast 3kB React alternative with the same modern API. Components & Virtual DOM.",
       "stars": 17096,
@@ -412,11 +420,11 @@
       "owner_id": 105127,
       "icon": "preact.svg",
       "created_at": "2015-09-11T02:40:18.000Z",
-      "url": "https://preactjs.com",
-      "slug": "preact"
+      "url": "https://preactjs.com"
     },
     {
       "name": "Rollup",
+      "slug": "rollup",
       "full_name": "rollup/rollup",
       "description": "Next-generation ES6 module bundler",
       "stars": 11463,
@@ -426,11 +434,11 @@
       "owner_id": 12554859,
       "icon": "rollup.svg",
       "created_at": "2015-05-14T22:26:28.000Z",
-      "url": "http://rollupjs.org",
-      "slug": "rollup"
+      "url": "http://rollupjs.org"
     },
     {
       "name": "Koa",
+      "slug": "koa",
       "full_name": "koajs/koa",
       "description": "Expressive middleware for node.js using ES2017 async functions",
       "stars": 19116,
@@ -439,11 +447,11 @@
       "tags": ["nodejs-framework"],
       "owner_id": 5055057,
       "created_at": "2013-07-20T18:53:45.000Z",
-      "url": "http://koajs.com",
-      "slug": "koa"
+      "url": "http://koajs.com"
     },
     {
       "name": "Gatsby",
+      "slug": "gatsby",
       "full_name": "gatsbyjs/gatsby",
       "description": "⚛️📄🚀 Blazing fast static site generator for React",
       "stars": 17146,
@@ -453,11 +461,11 @@
       "owner_id": 12551863,
       "icon": "gatsby.svg",
       "created_at": "2015-05-21T22:43:05.000Z",
-      "url": "https://www.gatsbyjs.org",
-      "slug": "gatsby"
+      "url": "https://www.gatsbyjs.org"
     },
     {
       "name": "Next.js",
+      "slug": "nextjs",
       "full_name": "zeit/next.js",
       "description": "Framework for server-rendered or statically-exported React apps",
       "stars": 20992,
@@ -467,10 +475,11 @@
       "owner_id": 14985020,
       "created_at": "2016-10-05T23:32:51.000Z",
       "url": "https://zeit.co/blog/next4",
-      "slug": "nextjs"
+      "icon": "nextjs.svg"
     },
     {
       "name": "Recharts",
+      "slug": "recharts",
       "full_name": "recharts/recharts",
       "description": "Redefined chart library built with React and D3",
       "stars": 7656,
@@ -479,11 +488,11 @@
       "tags": ["chart", "react", "d3", "svg"],
       "owner_id": 13690587,
       "created_at": "2015-08-07T06:50:27.000Z",
-      "url": "http://recharts.org",
-      "slug": "recharts"
+      "url": "http://recharts.org"
     },
     {
       "name": "Feathers",
+      "slug": "feathers",
       "full_name": "feathersjs/feathers",
       "description": "A REST and realtime API layer for modern applications.",
       "stars": 8180,
@@ -493,10 +502,11 @@
       "owner_id": 5321853,
       "created_at": "2011-10-19T22:45:16.000Z",
       "url": "https://feathersjs.com",
-      "slug": "feathers"
+      "icon": "feathers.svg"
     },
     {
       "name": "Jest",
+      "slug": "jest",
       "full_name": "facebook/jest",
       "description": "🃏 Delightful JavaScript Testing.",
       "stars": 14703,
@@ -506,11 +516,11 @@
       "owner_id": 69631,
       "icon": "jest.svg",
       "created_at": "2013-12-10T00:18:04.000Z",
-      "url": "http://facebook.github.io/jest/",
-      "slug": "jest"
+      "url": "http://facebook.github.io/jest/"
     },
     {
       "name": "Aurelia",
+      "slug": "aurelia",
       "full_name": "aurelia/framework",
       "description": "The aurelia framework brings together all the required core aurelia libraries into a ready-to-go app",
       "stars": 10346,
@@ -520,10 +530,11 @@
       "owner_id": 9808864,
       "created_at": "2014-12-10T19:22:29.000Z",
       "url": "http://aurelia.io/",
-      "slug": "aurelia"
+      "icon": "aurelia.svg"
     },
     {
       "name": "NativeScript",
+      "slug": "nativescript",
       "full_name": "NativeScript/NativeScript",
       "description": "NativeScript is an open source framework for building truly native mobile apps with JavaScript. Use ",
       "stars": 12115,
@@ -533,11 +544,11 @@
       "owner_id": 7392261,
       "icon": "nativescript.svg",
       "created_at": "2015-03-01T09:47:08.000Z",
-      "url": "http://www.nativescript.org",
-      "slug": "nativescript"
+      "url": "http://www.nativescript.org"
     },
     {
       "name": "Keystone",
+      "slug": "keystone",
       "full_name": "keystonejs/keystone",
       "description": "node.js cms and web app framework",
       "stars": 11742,
@@ -547,10 +558,11 @@
       "owner_id": 6118534,
       "created_at": "2013-07-02T05:01:55.000Z",
       "url": "http://www.keystonejs.com",
-      "slug": "keystone"
+      "icon": "keystone.svg"
     },
     {
       "name": "Sails",
+      "slug": "sails",
       "full_name": "balderdashy/sails",
       "description": "Realtime MVC Framework for Node.js",
       "stars": 18239,
@@ -560,10 +572,11 @@
       "owner_id": 1445252,
       "created_at": "2012-03-18T19:46:15.000Z",
       "url": "https://sailsjs.com",
-      "slug": "sails"
+      "icon": "sails.svg"
     },
     {
       "name": "Riot",
+      "slug": "riot",
       "full_name": "riot/riot",
       "description": "Simple and elegant component-based UI library",
       "stars": 12675,
@@ -573,10 +586,11 @@
       "owner_id": 12729373,
       "created_at": "2013-09-27T05:21:01.000Z",
       "url": "http://riotjs.com",
-      "slug": "riot"
+      "icon": "riot.svg"
     },
     {
       "name": "Mocha",
+      "slug": "mocha",
       "full_name": "mochajs/mocha",
       "description": "☕️ simple, flexible, fun javascript test framework for node.js & the browser",
       "stars": 14345,
@@ -586,10 +600,11 @@
       "owner_id": 8770005,
       "created_at": "2011-03-07T18:44:25.000Z",
       "url": "https://mochajs.org",
-      "slug": "mocha"
+      "icon": "mocha.svg"
     },
     {
       "name": "Polymer",
+      "slug": "polymer",
       "full_name": "Polymer/polymer",
       "description": "Build modern apps using web components",
       "stars": 18984,
@@ -599,10 +614,11 @@
       "owner_id": 2159051,
       "created_at": "2012-08-23T20:56:30.000Z",
       "url": "https://www.polymer-project.org/",
-      "slug": "polymer"
+      "icon": "polymer.svg"
     },
     {
       "name": "Cycle.js",
+      "slug": "cyclejs",
       "full_name": "cyclejs/cyclejs",
       "description": "A functional and reactive JavaScript framework for predictable code",
       "stars": 7884,
@@ -612,10 +628,11 @@
       "owner_id": 12686838,
       "created_at": "2014-11-07T11:28:45.000Z",
       "url": "http://cycle.js.org",
-      "slug": "cyclejs"
+      "icon": "cycle.svg"
     },
     {
       "name": "Nodal",
+      "slug": "nodal",
       "full_name": "keithwhor/nodal",
       "description": "API Services Made Easy With Node.js",
       "stars": 4523,
@@ -625,7 +642,7 @@
       "owner_id": 3936867,
       "created_at": "2015-04-19T06:34:05.000Z",
       "url": "http://www.nodaljs.com/",
-      "slug": "nodal"
+      "icon": "nodal.svg"
     },
     {
       "name": "Loopback",
@@ -638,10 +655,12 @@
       "tags": ["api", "nodejs-framework"],
       "owner_id": 3020012,
       "created_at": "2013-04-09T16:02:18.000Z",
-      "url": "http://loopback.io"
+      "url": "http://loopback.io",
+      "icon": "loopback3.svg"
     },
     {
       "name": "Brackets",
+      "slug": "brackets",
       "full_name": "adobe/brackets",
       "description": "An open source code editor for the web, written in JavaScript, HTML and CSS.",
       "stars": 28559,
@@ -651,11 +670,11 @@
       "owner_id": 476009,
       "icon": "brackets.svg",
       "created_at": "2011-12-07T21:14:40.000Z",
-      "url": "http://brackets.io",
-      "slug": "brackets"
+      "url": "http://brackets.io"
     },
     {
       "name": "Relay",
+      "slug": "relay",
       "full_name": "facebook/relay",
       "description": "Relay is a JavaScript framework for building data-driven React applications.",
       "stars": 10268,
@@ -665,11 +684,11 @@
       "owner_id": 69631,
       "icon": "relay.svg",
       "created_at": "2015-08-10T22:09:16.000Z",
-      "url": "https://facebook.github.io/relay/",
-      "slug": "relay"
+      "url": "https://facebook.github.io/relay/"
     },
     {
       "name": "Backbone",
+      "slug": "backbone",
       "full_name": "jashkenas/backbone",
       "description": "Give your JS App some Backbone with Models, Views, Collections, and Events",
       "stars": 26927,
@@ -679,11 +698,11 @@
       "owner_id": 4732,
       "icon": "backbone.svg",
       "created_at": "2010-09-30T19:41:28.000Z",
-      "url": "http://backbonejs.org",
-      "slug": "backbone"
+      "url": "http://backbonejs.org"
     },
     {
       "name": "Hapi",
+      "slug": "hapi",
       "full_name": "hapijs/hapi",
       "description": "Server Framework  for Node.js",
       "stars": 8924,
@@ -693,10 +712,11 @@
       "owner_id": 3774533,
       "created_at": "2011-08-06T00:35:39.000Z",
       "url": "hapijs.com",
-      "slug": "hapi"
+      "icon": "hapi.svg"
     },
     {
       "name": "Ember",
+      "slug": "ember",
       "full_name": "emberjs/ember.js",
       "description": "Ember.js - A JavaScript framework for creating ambitious web applications",
       "stars": 18601,
@@ -706,10 +726,11 @@
       "owner_id": 1253363,
       "created_at": "2011-05-25T23:39:40.000Z",
       "url": "http://www.emberjs.com",
-      "slug": "ember"
+      "icon": "ember.svg"
     },
     {
       "name": "Choo",
+      "slug": "choo",
       "full_name": "choojs/choo",
       "description": ":steam_locomotive::train: - sturdy 4kb frontend framework",
       "stars": 4940,
@@ -718,11 +739,11 @@
       "tags": ["framework"],
       "owner_id": 29929674,
       "created_at": "2016-05-10T17:50:35.000Z",
-      "url": "https://choo.io/",
-      "slug": "choo"
+      "url": "https://choo.io/"
     },
     {
       "name": "Reason",
+      "slug": "reason",
       "full_name": "facebook/reason",
       "description": "Simple, fast & type safe code that leverages the JavaScript & OCaml ecosystems",
       "stars": 4556,
@@ -732,11 +753,11 @@
       "owner_id": 69631,
       "icon": "reason.svg",
       "created_at": "2015-11-16T08:22:32.000Z",
-      "url": "http://reasonml.github.io",
-      "slug": "reason"
+      "url": "http://reasonml.github.io"
     },
     {
       "name": "Jasmine",
+      "slug": "jasmine",
       "full_name": "jasmine/jasmine",
       "description": "Simple JavaScript testing framework for browsers and node.js",
       "stars": 13183,
@@ -746,10 +767,11 @@
       "owner_id": 4624349,
       "created_at": "2008-12-02T23:46:37.000Z",
       "url": "http://jasmine.github.io/",
-      "slug": "jasmine"
+      "icon": "jasmine.svg"
     },
     {
       "name": "Restify",
+      "slug": "restify",
       "full_name": "restify/node-restify",
       "description": "The future of Node.js REST development",
       "stars": 7662,
@@ -758,11 +780,11 @@
       "tags": ["api", "nodejs-framework"],
       "owner_id": 6948699,
       "created_at": "2011-04-25T21:19:26.000Z",
-      "url": "http://restify.com",
-      "slug": "restify"
+      "url": "http://restify.com"
     },
     {
       "name": "Svelte",
+      "slug": "svelte",
       "full_name": "sveltejs/svelte",
       "description": "The magical disappearing UI framework",
       "stars": 6146,
@@ -772,10 +794,11 @@
       "owner_id": 23617963,
       "created_at": "2016-11-20T18:13:05.000Z",
       "url": "https://svelte.technology",
-      "slug": "svelte"
+      "icon": "svelte.svg"
     },
     {
       "name": "Browserify",
+      "slug": "browserify",
       "full_name": "browserify/browserify",
       "description": "browser-side require() the node.js way",
       "stars": 11675,
@@ -785,10 +808,11 @@
       "owner_id": 6320506,
       "created_at": "2010-09-22T16:11:32.000Z",
       "url": "http://browserify.org/",
-      "slug": "browserify"
+      "icon": "browserify.svg"
     },
     {
       "name": "Tape",
+      "slug": "tape",
       "full_name": "substack/tape",
       "description": "tap-producing test harness for node and browsers",
       "stars": 4339,
@@ -797,11 +821,11 @@
       "tags": ["test-framework", "test"],
       "owner_id": 12631,
       "created_at": "2012-11-25T17:08:02.000Z",
-      "url": "",
-      "slug": "tape"
+      "url": ""
     },
     {
       "name": "CoffeeScript",
+      "slug": "coffeescript",
       "full_name": "jashkenas/coffeescript",
       "description": "Unfancy JavaScript",
       "stars": 14502,
@@ -811,11 +835,11 @@
       "owner_id": 4732,
       "icon": "coffeescript.svg",
       "created_at": "2009-12-18T01:39:53.000Z",
-      "url": "http://coffeescript.org/",
-      "slug": "coffeescript"
+      "url": "http://coffeescript.org/"
     },
     {
       "name": "Metalsmith",
+      "slug": "metalsmith",
       "full_name": "segmentio/metalsmith",
       "description": "An extremely simple, pluggable static site generator.",
       "stars": 6487,
@@ -824,11 +848,11 @@
       "tags": ["ssg"],
       "owner_id": 819518,
       "created_at": "2014-02-04T03:46:22.000Z",
-      "url": "http://metalsmith.io",
-      "slug": "metalsmith"
+      "url": "http://metalsmith.io"
     },
     {
       "name": "ClojureScript",
+      "slug": "clojurescript",
       "full_name": "clojure/clojurescript",
       "description": "Clojure to JS compiler",
       "stars": 7464,
@@ -838,10 +862,11 @@
       "owner_id": 317875,
       "created_at": "2011-07-20T23:29:13.000Z",
       "url": "http://clojurescript.org/",
-      "slug": "clojurescript"
+      "icon": "clojure.svg"
     },
     {
       "name": "Deco IDE",
+      "slug": "deco-ide",
       "full_name": "decosoftware/deco-ide",
       "description": "The React Native IDE",
       "stars": 5463,
@@ -850,11 +875,11 @@
       "tags": ["ide"],
       "owner_id": 14793641,
       "created_at": "2016-05-19T21:29:00.000Z",
-      "url": "https://www.decosoftware.com/",
-      "slug": "deco-ide"
+      "url": "https://www.decosoftware.com/"
     },
     {
       "name": "Purescript",
+      "slug": "purescript",
       "full_name": "purescript/purescript",
       "description": "A strongly-typed language that compiles to Javascript",
       "stars": 4371,
@@ -863,11 +888,11 @@
       "tags": ["compiler"],
       "owner_id": 6556677,
       "created_at": "2013-09-30T05:29:23.000Z",
-      "url": "http://purescript.org",
-      "slug": "purescript"
+      "url": "http://purescript.org"
     },
     {
       "name": "Adonis",
+      "slug": "adonis",
       "full_name": "adonisjs/adonis-framework",
       "description": "NodeJs Web Application Framework. Makes it easy for you to write webapps with less code :smiley:",
       "stars": 3394,
@@ -876,11 +901,11 @@
       "tags": ["nodejs-framework"],
       "owner_id": 13810373,
       "created_at": "2015-08-15T17:03:54.000Z",
-      "url": "http://adonisjs.com",
-      "slug": "adonis"
+      "url": "http://adonisjs.com"
     },
     {
       "name": "Grunt",
+      "slug": "grunt",
       "full_name": "gruntjs/grunt",
       "description": "Grunt: The JavaScript Task Runner",
       "stars": 11702,
@@ -890,10 +915,11 @@
       "owner_id": 1630826,
       "created_at": "2011-09-21T15:16:20.000Z",
       "url": "http://gruntjs.com/",
-      "slug": "grunt"
+      "icon": "grunt.svg"
     },
     {
       "name": "Flow",
+      "slug": "flow",
       "full_name": "facebook/flow",
       "description": "Adds static typing to JavaScript to improve developer productivity and code quality.",
       "stars": 14950,
@@ -903,8 +929,7 @@
       "owner_id": 69631,
       "icon": "flow.svg",
       "created_at": "2014-10-28T17:17:45.000Z",
-      "url": "https://flow.org/",
-      "slug": "flow"
+      "url": "https://flow.org/"
     }
   ],
   "tags": [

--- a/data/2017/projects.json
+++ b/data/2017/projects.json
@@ -2,6 +2,7 @@
   "projects": [
     {
       "name": "Vue.js",
+      "slug": "vuejs",
       "full_name": "vuejs/vue",
       "description": "🖖 A progressive, incrementally-adoptable JavaScript framework for building UI on the web.",
       "stars": 80749,
@@ -13,11 +14,11 @@
       "owner_id": 6128107,
       "icon": "vue.svg",
       "created_at": "2013-07-29T03:24:51.000Z",
-      "url": "http://vuejs.org",
-      "slug": "vuejs"
+      "url": "http://vuejs.org"
     },
     {
       "name": "React",
+      "slug": "react",
       "full_name": "facebook/react",
       "description": "A declarative, efficient, and flexible JavaScript library for building user interfaces.",
       "stars": 86238,
@@ -29,11 +30,11 @@
       "owner_id": 69631,
       "icon": "react.svg",
       "created_at": "2013-05-24T16:15:54.000Z",
-      "url": "https://reactjs.org",
-      "slug": "react"
+      "url": "https://reactjs.org"
     },
     {
       "name": "Create React App",
+      "slug": "create-react-app",
       "full_name": "facebookincubator/create-react-app",
       "description": "Create React apps with no build configuration.",
       "stars": 41439,
@@ -45,10 +46,11 @@
       "owner_id": 19538647,
       "created_at": "2016-07-17T14:55:11.000Z",
       "url": "",
-      "slug": "create-react-app"
+      "icon": "cra.svg"
     },
     {
       "name": "Puppeteer",
+      "slug": "puppeteer",
       "full_name": "GoogleChrome/puppeteer",
       "description": "Headless Chrome Node API",
       "stars": 23986,
@@ -58,10 +60,11 @@
       "owner_id": 1778935,
       "created_at": "2017-05-09T22:16:13.000Z",
       "url": "",
-      "slug": "puppeteer"
+      "icon": "puppeteer.svg"
     },
     {
       "name": "Axios",
+      "slug": "axios",
       "full_name": "axios/axios",
       "description": "Promise based HTTP client for the browser and node.js",
       "stars": 34477,
@@ -73,10 +76,11 @@
       "owner_id": 32372333,
       "created_at": "2014-08-18T22:30:27.000Z",
       "url": "",
-      "slug": "axios"
+      "icon": "axios.svg"
     },
     {
       "name": "VS Code",
+      "slug": "vs-code",
       "full_name": "Microsoft/vscode",
       "description": "Visual Studio Code",
       "stars": 42501,
@@ -88,11 +92,11 @@
       "owner_id": 6154722,
       "icon": "vscode.svg",
       "created_at": "2015-09-03T20:23:38.000Z",
-      "url": "https://code.visualstudio.com",
-      "slug": "vs-code"
+      "url": "https://code.visualstudio.com"
     },
     {
       "name": "Prettier",
+      "slug": "prettier",
       "full_name": "prettier/prettier",
       "description": "Prettier is an opinionated code formatter.",
       "stars": 20371,
@@ -104,11 +108,11 @@
       "owner_id": 25822731,
       "icon": "prettier.svg",
       "created_at": "2016-11-29T17:13:37.000Z",
-      "url": "https://prettier.io/",
-      "slug": "prettier"
+      "url": "https://prettier.io/"
     },
     {
       "name": "React Native",
+      "slug": "react-native",
       "full_name": "facebook/react-native",
       "description": "A framework for building native apps with React.",
       "stars": 58711,
@@ -120,10 +124,11 @@
       "owner_id": 69631,
       "created_at": "2015-01-09T18:10:16.000Z",
       "url": "http://facebook.github.io/react-native/",
-      "slug": "react-native"
+      "icon": "react-native.svg"
     },
     {
       "name": "Element",
+      "slug": "element",
       "full_name": "ElemeFE/element",
       "description": "A Vue.js 2.0 UI Toolkit for Web",
       "stars": 22385,
@@ -135,10 +140,11 @@
       "owner_id": 12810740,
       "created_at": "2016-09-03T06:19:26.000Z",
       "url": "http://element.eleme.io/",
-      "slug": "element"
+      "icon": "element.svg"
     },
     {
       "name": "Electron",
+      "slug": "electron",
       "full_name": "electron/electron",
       "description": "Build cross platform desktop apps with JavaScript, HTML, and CSS",
       "stars": 55513,
@@ -150,10 +156,11 @@
       "owner_id": 13409222,
       "created_at": "2013-04-12T01:47:36.000Z",
       "url": "https://electronjs.org",
-      "slug": "electron"
+      "icon": "electron.svg"
     },
     {
       "name": "Bootstrap",
+      "slug": "bootstrap",
       "full_name": "twbs/bootstrap",
       "description": "The most popular HTML, CSS, and JavaScript framework for developing responsive, mobile first project",
       "stars": 120751,
@@ -165,10 +172,11 @@
       "owner_id": 2918581,
       "created_at": "2011-07-29T21:19:00.000Z",
       "url": "http://getbootstrap.com",
-      "slug": "bootstrap"
+      "icon": "bootstrap.svg"
     },
     {
       "name": "Parcel",
+      "slug": "parcel",
       "full_name": "parcel-bundler/parcel",
       "description": "📦🚀 Blazing fast, zero configuration web application bundler",
       "stars": 16940,
@@ -178,10 +186,11 @@
       "owner_id": 32607881,
       "created_at": "2017-08-07T16:36:47.000Z",
       "url": "https://parceljs.org",
-      "slug": "parcel"
+      "icon": "parcel.svg"
     },
     {
       "name": "Node.js",
+      "slug": "nodejs",
       "full_name": "nodejs/node",
       "description": "Node.js JavaScript runtime :sparkles::turtle::rocket::sparkles:",
       "stars": 44626,
@@ -193,10 +202,11 @@
       "owner_id": 9950313,
       "created_at": "2014-11-26T19:57:11.000Z",
       "url": "https://nodejs.org",
-      "slug": "nodejs"
+      "icon": "nodejs.svg"
     },
     {
       "name": "Ant Design",
+      "slug": "ant-design",
       "full_name": "ant-design/ant-design",
       "description": "🐜 A UI Design Language",
       "stars": 23119,
@@ -206,10 +216,11 @@
       "owner_id": 12101536,
       "created_at": "2015-04-24T15:37:24.000Z",
       "url": "http://ant.design",
-      "slug": "ant-design"
+      "icon": "ant.svg"
     },
     {
       "name": "Webpack",
+      "slug": "webpack",
       "full_name": "webpack/webpack",
       "description": "A bundler for javascript and friends. Packs many modules into a few bundled assets. Code Splitting a",
       "stars": 36136,
@@ -221,11 +232,11 @@
       "owner_id": 2105791,
       "icon": "webpack.svg",
       "created_at": "2012-03-10T10:08:14.000Z",
-      "url": "https://webpack.js.org",
-      "slug": "webpack"
+      "url": "https://webpack.js.org"
     },
     {
       "name": "Next.js",
+      "slug": "nextjs",
       "full_name": "zeit/next.js",
       "description": "Framework for server-rendered or statically-exported React apps",
       "stars": 21447,
@@ -237,10 +248,11 @@
       "owner_id": 14985020,
       "created_at": "2016-10-05T23:32:51.000Z",
       "url": "https://zeit.co/blog/next4",
-      "slug": "nextjs"
+      "icon": "nextjs.svg"
     },
     {
       "name": "D3",
+      "slug": "d3",
       "full_name": "d3/d3",
       "description": "Bring data to life with SVG, Canvas and HTML. :bar_chart::chart_with_upwards_trend::tada:",
       "stars": 71804,
@@ -252,10 +264,11 @@
       "owner_id": 1562726,
       "created_at": "2010-09-27T17:22:42.000Z",
       "url": "https://d3js.org",
-      "slug": "d3"
+      "icon": "d3.svg"
     },
     {
       "name": "Angular",
+      "slug": "angular",
       "full_name": "angular/angular",
       "description": "One framework. Mobile & desktop.",
       "stars": 32207,
@@ -267,11 +280,11 @@
       "owner_id": 139426,
       "icon": "angular.svg",
       "created_at": "2014-09-18T16:12:01.000Z",
-      "url": "https://angular.io",
-      "slug": "angular"
+      "url": "https://angular.io"
     },
     {
       "name": "Bulma",
+      "slug": "bulma",
       "full_name": "jgthms/bulma",
       "description": "Modern CSS framework based on Flexbox",
       "stars": 23746,
@@ -283,10 +296,11 @@
       "owner_id": 1254808,
       "created_at": "2016-01-23T23:48:34.000Z",
       "url": "https://bulma.io",
-      "slug": "bulma"
+      "icon": "bulma.svg"
     },
     {
       "name": "TypeScript",
+      "slug": "typescript",
       "full_name": "Microsoft/TypeScript",
       "description": "TypeScript is a superset of JavaScript that compiles to clean JavaScript output.",
       "stars": 30154,
@@ -298,11 +312,11 @@
       "owner_id": 6154722,
       "icon": "typescript.svg",
       "created_at": "2014-06-17T15:28:39.000Z",
-      "url": "http://www.typescriptlang.org",
-      "slug": "typescript"
+      "url": "http://www.typescriptlang.org"
     },
     {
       "name": "Preact",
+      "slug": "preact",
       "full_name": "developit/preact",
       "description": "⚛️ Fast 3kB React alternative with the same modern API. Components & Virtual DOM.",
       "stars": 17281,
@@ -312,11 +326,11 @@
       "owner_id": 105127,
       "icon": "preact.svg",
       "created_at": "2015-09-11T02:40:18.000Z",
-      "url": "https://preactjs.com",
-      "slug": "preact"
+      "url": "https://preactjs.com"
     },
     {
       "name": "Redux",
+      "slug": "redux",
       "full_name": "reactjs/redux",
       "description": "Predictable state container for JavaScript apps",
       "stars": 37471,
@@ -326,11 +340,11 @@
       "owner_id": 6412038,
       "icon": "redux.svg",
       "created_at": "2015-05-29T23:53:15.000Z",
-      "url": "http://redux.js.org",
-      "slug": "redux"
+      "url": "http://redux.js.org"
     },
     {
       "name": "Animate.css",
+      "slug": "animatecss",
       "full_name": "daneden/animate.css",
       "description": "🍿 A cross-browser library of CSS animations. As easy to use as an easy thing.",
       "stars": 48456,
@@ -339,11 +353,11 @@
       "tags": ["animation"],
       "owner_id": 439365,
       "created_at": "2011-10-12T10:07:38.000Z",
-      "url": "http://daneden.github.io/animate.css",
-      "slug": "animatecss"
+      "url": "http://daneden.github.io/animate.css"
     },
     {
       "name": "Storybook",
+      "slug": "storybook",
       "full_name": "storybooks/storybook",
       "description": "Interactive UI component dev & test: React, React Native, Vue, Angular",
       "stars": 19089,
@@ -355,10 +369,11 @@
       "owner_id": 22632046,
       "created_at": "2016-03-18T04:23:44.000Z",
       "url": "https://storybook.js.org",
-      "slug": "storybook"
+      "icon": "storybook.svg"
     },
     {
       "name": "Gatsby",
+      "slug": "gatsby",
       "full_name": "gatsbyjs/gatsby",
       "description": "⚛️📄🚀 Blazing fast static site generator for React",
       "stars": 17715,
@@ -370,11 +385,11 @@
       "owner_id": 12551863,
       "icon": "gatsby.svg",
       "created_at": "2015-05-21T22:43:05.000Z",
-      "url": "https://www.gatsbyjs.org",
-      "slug": "gatsby"
+      "url": "https://www.gatsbyjs.org"
     },
     {
       "name": "Material UI",
+      "slug": "material-ui",
       "full_name": "mui-org/material-ui",
       "description": "React components that implement Google's Material Design.",
       "stars": 32422,
@@ -384,10 +399,11 @@
       "owner_id": 33663932,
       "created_at": "2014-08-18T19:11:54.000Z",
       "url": "http://www.material-ui.com",
-      "slug": "material-ui"
+      "icon": "material-ui.svg"
     },
     {
       "name": "json-server",
+      "slug": "json-server",
       "full_name": "typicode/json-server",
       "description": "Get a full fake REST API with zero coding in less than 30 seconds (seriously)",
       "stars": 28243,
@@ -396,11 +412,11 @@
       "tags": ["test"],
       "owner_id": 5502029,
       "created_at": "2013-11-27T13:21:13.000Z",
-      "url": "",
-      "slug": "json-server"
+      "url": ""
     },
     {
       "name": "iView",
+      "slug": "iview",
       "full_name": "iview/iview",
       "description": "A high quality UI Toolkit built on Vue.js 2.0",
       "stars": 12359,
@@ -410,10 +426,11 @@
       "owner_id": 20693613,
       "created_at": "2016-07-28T01:52:59.000Z",
       "url": "https://iviewui.com/",
-      "slug": "iview"
+      "icon": "iview.svg"
     },
     {
       "name": "Feather",
+      "slug": "feather",
       "full_name": "feathericons/feather",
       "description": "Simply beautiful open source icons",
       "stars": 11923,
@@ -422,11 +439,11 @@
       "tags": ["icon", "svg"],
       "owner_id": 29268069,
       "created_at": "2014-05-28T19:49:55.000Z",
-      "url": "https://feathericons.com",
-      "slug": "feather"
+      "url": "https://feathericons.com"
     },
     {
       "name": "Atom",
+      "slug": "atom",
       "full_name": "atom/atom",
       "description": ":atom: The hackable text editor",
       "stars": 42940,
@@ -436,10 +453,11 @@
       "owner_id": 1089146,
       "created_at": "2012-01-20T18:18:21.000Z",
       "url": "https://atom.io",
-      "slug": "atom"
+      "icon": "atom.svg"
     },
     {
       "name": "Frappé Charts",
+      "slug": "frappe-charts",
       "full_name": "frappe/charts",
       "description": "📊🍩📈 Simple, responsive, modern SVG Charts with zero dependencies",
       "stars": 10186,
@@ -448,11 +466,11 @@
       "tags": ["chart", "svg"],
       "owner_id": 836974,
       "created_at": "2017-10-26T10:13:21.000Z",
-      "url": "https://frappe.github.io/charts",
-      "slug": "frappe-charts"
+      "url": "https://frappe.github.io/charts"
     },
     {
       "name": "React Navigation",
+      "slug": "react-navigation",
       "full_name": "react-navigation/react-navigation",
       "description": "Learn once, navigate anywhere",
       "stars": 9125,
@@ -461,11 +479,11 @@
       "tags": ["routing", "react-native"],
       "owner_id": 29647600,
       "created_at": "2017-01-26T19:51:40.000Z",
-      "url": "https://reactnavigation.org",
-      "slug": "react-navigation"
+      "url": "https://reactnavigation.org"
     },
     {
       "name": "Styled Components",
+      "slug": "styled-components",
       "full_name": "styled-components/styled-components",
       "description": "Visual primitives for the component age. Use the best bits of ES6 and CSS to style your apps without",
       "stars": 12782,
@@ -474,11 +492,11 @@
       "tags": ["css-in-js"],
       "owner_id": 20658825,
       "created_at": "2016-08-16T06:41:32.000Z",
-      "url": "http://styled-components.com",
-      "slug": "styled-components"
+      "url": "http://styled-components.com"
     },
     {
       "name": "React Router",
+      "slug": "react-router",
       "full_name": "ReactTraining/react-router",
       "description": "Declarative routing for React",
       "stars": 27694,
@@ -488,10 +506,11 @@
       "owner_id": 11823761,
       "created_at": "2014-05-16T22:22:51.000Z",
       "url": "https://reacttraining.com/react-router/",
-      "slug": "react-router"
+      "icon": "react-router.svg"
     },
     {
       "name": "socket.io",
+      "slug": "socketio",
       "full_name": "socketio/socket.io",
       "description": "Realtime application framework (Node.JS server)",
       "stars": 38667,
@@ -501,10 +520,11 @@
       "owner_id": 10566080,
       "created_at": "2010-03-11T18:24:48.000Z",
       "url": "http://socket.io",
-      "slug": "socketio"
+      "icon": "socketio.svg"
     },
     {
       "name": "Hyperapp",
+      "slug": "hyperapp",
       "full_name": "hyperapp/hyperapp",
       "description": "1 KB JavaScript library for building web applications.",
       "stars": 10266,
@@ -514,10 +534,11 @@
       "owner_id": 25238911,
       "created_at": "2017-01-20T05:20:21.000Z",
       "url": "https://hyperapp.js.org",
-      "slug": "hyperapp"
+      "icon": "hyperapp.svg"
     },
     {
       "name": "Create React Native App",
+      "slug": "create-react-native-app",
       "full_name": "react-community/create-react-native-app",
       "description": "Create a React Native app on any OS with no build config.",
       "stars": 7925,
@@ -526,11 +547,11 @@
       "tags": ["react-native"],
       "owner_id": 24483500,
       "created_at": "2017-01-11T17:54:30.000Z",
-      "url": "",
-      "slug": "create-react-native-app"
+      "url": ""
     },
     {
       "name": "Reactide",
+      "slug": "reactide",
       "full_name": "reactide/reactide",
       "description": "Reactide is the first dedicated IDE for React web application development. http://reactide.io",
       "stars": 7584,
@@ -539,11 +560,11 @@
       "tags": ["ide"],
       "owner_id": 26257999,
       "created_at": "2017-03-07T18:30:34.000Z",
-      "url": "http://reactide.io",
-      "slug": "reactide"
+      "url": "http://reactide.io"
     },
     {
       "name": "Vuex",
+      "slug": "vuex",
       "full_name": "vuejs/vuex",
       "description": "🗃️ Centralized State Management for Vue.js.",
       "stars": 12294,
@@ -552,11 +573,11 @@
       "tags": ["flux", "vue", "state"],
       "owner_id": 6128107,
       "created_at": "2015-07-16T04:21:26.000Z",
-      "url": "https://vuex.vuejs.org",
-      "slug": "vuex"
+      "url": "https://vuex.vuejs.org"
     },
     {
       "name": "Jest",
+      "slug": "jest",
       "full_name": "facebook/jest",
       "description": "🃏 Delightful JavaScript Testing.",
       "stars": 15014,
@@ -566,11 +587,11 @@
       "owner_id": 69631,
       "icon": "jest.svg",
       "created_at": "2013-12-10T00:18:04.000Z",
-      "url": "http://facebook.github.io/jest/",
-      "slug": "jest"
+      "url": "http://facebook.github.io/jest/"
     },
     {
       "name": "Express",
+      "slug": "express",
       "full_name": "expressjs/express",
       "description": "Fast, unopinionated, minimalist web framework for node.",
       "stars": 36186,
@@ -580,10 +601,11 @@
       "owner_id": 5658226,
       "created_at": "2009-06-26T18:56:01.000Z",
       "url": "https://expressjs.com",
-      "slug": "express"
+      "icon": "express.svg"
     },
     {
       "name": "Weex",
+      "slug": "weex",
       "full_name": "apache/incubator-weex",
       "description": "A framework for building Mobile cross-platform UI.",
       "stars": 7473,
@@ -593,11 +615,11 @@
       "owner_id": 47359,
       "icon": "weex.svg",
       "created_at": "2017-01-06T08:00:06.000Z",
-      "url": "https://weex.apache.org/",
-      "slug": "weex"
+      "url": "https://weex.apache.org/"
     },
     {
       "name": "Nuxt",
+      "slug": "nuxt",
       "full_name": "nuxt/nuxt.js",
       "description": "Versatile Vue.js Framework",
       "stars": 9186,
@@ -607,10 +629,11 @@
       "owner_id": 23360933,
       "created_at": "2016-10-26T11:18:47.000Z",
       "url": "https://nuxtjs.org",
-      "slug": "nuxt"
+      "icon": "nuxt.svg"
     },
     {
       "name": "Vuetify",
+      "slug": "vuetify",
       "full_name": "vuetifyjs/vuetify",
       "description": "Material Component Framework for Vue.js 2",
       "stars": 7832,
@@ -620,10 +643,11 @@
       "owner_id": 22138497,
       "created_at": "2016-09-12T00:39:35.000Z",
       "url": "https://vuetifyjs.com",
-      "slug": "vuetify"
+      "icon": "vuetify.svg"
     },
     {
       "name": "Hexo",
+      "slug": "hexo",
       "full_name": "hexojs/hexo",
       "description": "A fast, simple & powerful blog framework, powered by Node.js.",
       "stars": 20265,
@@ -633,10 +657,11 @@
       "owner_id": 6375567,
       "created_at": "2012-09-23T15:17:08.000Z",
       "url": "https://hexo.io",
-      "slug": "hexo"
+      "icon": "hexo.svg"
     },
     {
       "name": "Koa",
+      "slug": "koa",
       "full_name": "koajs/koa",
       "description": "Expressive middleware for node.js using ES2017 async functions",
       "stars": 19283,
@@ -645,11 +670,11 @@
       "tags": ["nodejs-framework"],
       "owner_id": 5055057,
       "created_at": "2013-07-20T18:53:45.000Z",
-      "url": "http://koajs.com",
-      "slug": "koa"
+      "url": "http://koajs.com"
     },
     {
       "name": "Fastify",
+      "slug": "fastify",
       "full_name": "fastify/fastify",
       "description": "Fast and low overhead web framework, for Node.js",
       "stars": 6041,
@@ -659,10 +684,11 @@
       "owner_id": 24939410,
       "created_at": "2016-09-28T19:10:14.000Z",
       "url": "https://www.fastify.io",
-      "slug": "fastify"
+      "icon": "fastify.svg"
     },
     {
       "name": "Babel",
+      "slug": "babel",
       "full_name": "babel/babel",
       "description": ":tropical_fish: Babel is a compiler for writing next generation JavaScript.",
       "stars": 25398,
@@ -672,10 +698,11 @@
       "owner_id": 9637642,
       "created_at": "2014-09-28T13:38:23.000Z",
       "url": "https://babeljs.io/",
-      "slug": "babel"
+      "icon": "babel.svg"
     },
     {
       "name": "Ant Design Pro",
+      "slug": "ant-design-pro",
       "full_name": "ant-design/ant-design-pro",
       "description": "👨🏻‍💻👩🏻‍💻 An out-of-box UI solution for enterprise applications",
       "stars": 6779,
@@ -685,10 +712,11 @@
       "owner_id": 12101536,
       "created_at": "2017-08-25T10:40:44.000Z",
       "url": "http://pro.ant.design/",
-      "slug": "ant-design-pro"
+      "icon": "ant.svg"
     },
     {
       "name": "Mint UI",
+      "slug": "mint-ui",
       "full_name": "ElemeFE/mint-ui",
       "description": "Mobile UI elements for Vue.js",
       "stars": 9352,
@@ -698,10 +726,11 @@
       "owner_id": 12810740,
       "created_at": "2016-05-17T09:54:10.000Z",
       "url": "http://mint-ui.github.io/#!/en",
-      "slug": "mint-ui"
+      "icon": "mint-ui.svg"
     },
     {
       "name": "Ionic",
+      "slug": "ionic",
       "full_name": "ionic-team/ionic",
       "description": "Build amazing native and progressive web apps with open web technologies. One app running on everyth",
       "stars": 32994,
@@ -711,10 +740,11 @@
       "owner_id": 3171503,
       "created_at": "2013-08-20T23:06:02.000Z",
       "url": "https://ionicframework.com/",
-      "slug": "ionic"
+      "icon": "ionic.svg"
     },
     {
       "name": "React boilerplate",
+      "slug": "react-boilerplate",
       "full_name": "react-boilerplate/react-boilerplate",
       "description": ":fire: A highly scalable, offline-first foundation with the best developer experience and a focus on",
       "stars": 16781,
@@ -723,11 +753,11 @@
       "tags": ["boilerplate", "react", "redux", "offline"],
       "owner_id": 25323389,
       "created_at": "2015-02-18T14:36:32.000Z",
-      "url": "https://www.reactboilerplate.com",
-      "slug": "react-boilerplate"
+      "url": "https://www.reactboilerplate.com"
     },
     {
       "name": "dva",
+      "slug": "dva",
       "full_name": "dvajs/dva",
       "description": "🌱 React and redux based, lightweight and elm-style framework. (Inspired by elm and choo)",
       "stars": 7621,
@@ -736,11 +766,11 @@
       "tags": ["framework", "redux"],
       "owner_id": 20552239,
       "created_at": "2016-06-24T09:06:16.000Z",
-      "url": "",
-      "slug": "dva"
+      "url": ""
     },
     {
       "name": "Flow",
+      "slug": "flow",
       "full_name": "facebook/flow",
       "description": "Adds static typing to JavaScript to improve developer productivity and code quality.",
       "stars": 15097,
@@ -750,11 +780,11 @@
       "owner_id": 69631,
       "icon": "flow.svg",
       "created_at": "2014-10-28T17:17:45.000Z",
-      "url": "https://flow.org/",
-      "slug": "flow"
+      "url": "https://flow.org/"
     },
     {
       "name": "Recompose",
+      "slug": "recompose",
       "full_name": "acdlite/recompose",
       "description": "A React utility belt for function components and higher-order components.",
       "stars": 8705,
@@ -763,11 +793,11 @@
       "tags": ["react"],
       "owner_id": 3624098,
       "created_at": "2015-10-07T05:54:51.000Z",
-      "url": "",
-      "slug": "recompose"
+      "url": ""
     },
     {
       "name": "react-loadable",
+      "slug": "react-loadable",
       "full_name": "thejameskyle/react-loadable",
       "description": ":hourglass_flowing_sand: A higher order component for loading components with promises.",
       "stars": 5556,
@@ -776,11 +806,11 @@
       "tags": ["isomorphic", "react"],
       "owner_id": 952783,
       "created_at": "2017-03-09T18:41:17.000Z",
-      "url": "",
-      "slug": "react-loadable"
+      "url": ""
     },
     {
       "name": "AVA",
+      "slug": "ava",
       "full_name": "avajs/ava",
       "description": ":rocket: Futuristic JavaScript test runner",
       "stars": 12523,
@@ -790,10 +820,11 @@
       "owner_id": 8527916,
       "created_at": "2014-11-18T17:20:26.000Z",
       "url": "",
-      "slug": "ava"
+      "icon": "ava.svg"
     },
     {
       "name": "vux",
+      "slug": "vux",
       "full_name": "airyland/vux",
       "description": "Mobile UI Components based on Vue & WeUI",
       "stars": 10954,
@@ -802,11 +833,11 @@
       "tags": ["vue"],
       "owner_id": 559179,
       "created_at": "2016-02-15T03:23:27.000Z",
-      "url": "https://vux.li/",
-      "slug": "vux"
+      "url": "https://vux.li/"
     },
     {
       "name": "vue-router",
+      "slug": "vue-router",
       "full_name": "vuejs/vue-router",
       "description": "🚦 The official router for Vue.js.",
       "stars": 8495,
@@ -815,11 +846,11 @@
       "tags": ["vue", "routing"],
       "owner_id": 6128107,
       "created_at": "2013-12-11T19:37:46.000Z",
-      "url": "http://router.vuejs.org/",
-      "slug": "vue-router"
+      "url": "http://router.vuejs.org/"
     },
     {
       "name": "Inferno",
+      "slug": "inferno",
       "full_name": "infernojs/inferno",
       "description": "An extremely fast, React-like JavaScript library for building modern user interfaces",
       "stars": 12071,
@@ -829,10 +860,11 @@
       "owner_id": 14214240,
       "created_at": "2015-02-01T22:07:38.000Z",
       "url": "http://infernojs.org",
-      "slug": "inferno"
+      "icon": "inferno.svg"
     },
     {
       "name": "NativeBase",
+      "slug": "nativebase",
       "full_name": "GeekyAnts/NativeBase",
       "description": "Essential cross-platform UI components for React Native",
       "stars": 7384,
@@ -842,10 +874,11 @@
       "owner_id": 18482943,
       "created_at": "2016-04-15T11:37:23.000Z",
       "url": "https://nativebase.io/",
-      "slug": "nativebase"
+      "icon": "nativebase.svg"
     },
     {
       "name": "Enzyme",
+      "slug": "enzyme",
       "full_name": "airbnb/enzyme",
       "description": "JavaScript Testing utilities for React",
       "stars": 12408,
@@ -854,11 +887,11 @@
       "tags": ["test", "react"],
       "owner_id": 698437,
       "created_at": "2015-11-10T21:45:38.000Z",
-      "url": "http://airbnb.io/enzyme/",
-      "slug": "enzyme"
+      "url": "http://airbnb.io/enzyme/"
     },
     {
       "name": "React Starter Kit",
+      "slug": "react-starter-kit",
       "full_name": "kriasoft/react-starter-kit",
       "description": "React Starter Kit — isomorphic web app boilerplate (Node.js, Express, GraphQL, React.js, Babel, Post",
       "stars": 16663,
@@ -867,11 +900,11 @@
       "tags": ["react", "isomorphic", "boilerplate", "graphql"],
       "owner_id": 773036,
       "created_at": "2014-04-16T13:08:18.000Z",
-      "url": "https://reactstarter.com",
-      "slug": "react-starter-kit"
+      "url": "https://reactstarter.com"
     },
     {
       "name": "Apollo client",
+      "slug": "apollo-client",
       "full_name": "apollographql/apollo-client",
       "description": ":rocket: A fully-featured, production ready caching GraphQL client for every UI framework and GraphQ",
       "stars": 5662,
@@ -881,10 +914,11 @@
       "owner_id": 17189275,
       "created_at": "2016-02-26T20:25:00.000Z",
       "url": "https://www.apollographql.com/client/",
-      "slug": "apollo-client"
+      "icon": "apollo.svg"
     },
     {
       "name": "Vue material",
+      "slug": "vue-material",
       "full_name": "vuematerial/vue-material",
       "description": "Material design for Vue.js",
       "stars": 5282,
@@ -893,11 +927,11 @@
       "tags": ["vue", "material"],
       "owner_id": 23659108,
       "created_at": "2016-06-17T22:41:53.000Z",
-      "url": "http://vuematerial.io",
-      "slug": "vue-material"
+      "url": "http://vuematerial.io"
     },
     {
       "name": "Quasar",
+      "slug": "quasar",
       "full_name": "quasarframework/quasar",
       "description": "Quasar Framework",
       "stars": 4788,
@@ -907,10 +941,11 @@
       "owner_id": 23064371,
       "created_at": "2015-10-05T15:45:36.000Z",
       "url": "http://quasar-framework.org",
-      "slug": "quasar"
+      "icon": "quasar.svg"
     },
     {
       "name": "Moon",
+      "slug": "moon",
       "full_name": "kbrsh/moon",
       "description": "🌙 ⚡️ A minimal, blazing fast UI library.",
       "stars": 4175,
@@ -919,11 +954,11 @@
       "tags": ["framework"],
       "owner_id": 15644571,
       "created_at": "2016-07-14T04:53:09.000Z",
-      "url": "http://moonjs.ga/",
-      "slug": "moon"
+      "url": "http://moonjs.ga/"
     },
     {
       "name": "Angular 1",
+      "slug": "angular-1",
       "full_name": "angular/angular.js",
       "description": "AngularJS - HTML enhanced for web apps!",
       "stars": 57856,
@@ -933,11 +968,11 @@
       "owner_id": 139426,
       "icon": "angularjs.svg",
       "created_at": "2010-01-06T00:34:37.000Z",
-      "url": "https://angularjs.org",
-      "slug": "angular-1"
+      "url": "https://angularjs.org"
     },
     {
       "name": "Gulp",
+      "slug": "gulp",
       "full_name": "gulpjs/gulp",
       "description": "The streaming build system",
       "stars": 28525,
@@ -947,10 +982,11 @@
       "owner_id": 6200624,
       "created_at": "2013-07-04T05:26:06.000Z",
       "url": "http://gulpjs.com",
-      "slug": "gulp"
+      "icon": "gulp.svg"
     },
     {
       "name": "Rollup",
+      "slug": "rollup",
       "full_name": "rollup/rollup",
       "description": "Next-generation ES6 module bundler",
       "stars": 11573,
@@ -960,10 +996,11 @@
       "owner_id": 12554859,
       "created_at": "2015-05-14T22:26:28.000Z",
       "url": "http://rollupjs.org",
-      "slug": "rollup"
+      "icon": "rollup.svg"
     },
     {
       "name": "Gun",
+      "slug": "gun",
       "full_name": "amark/gun",
       "description": "A realtime, decentralized, offline-first, graph database engine.",
       "stars": 7155,
@@ -973,11 +1010,11 @@
       "owner_id": 433412,
       "icon": "gun.svg",
       "created_at": "2014-07-31T15:52:10.000Z",
-      "url": "http://gun.js.org/",
-      "slug": "gun"
+      "url": "http://gun.js.org/"
     },
     {
       "name": "micro",
+      "slug": "micro",
       "full_name": "zeit/micro",
       "description": "Asynchronous HTTP microservices",
       "stars": 5900,
@@ -986,11 +1023,11 @@
       "tags": ["microservice", "nodejs-framework"],
       "owner_id": 14985020,
       "created_at": "2016-01-23T05:17:00.000Z",
-      "url": "https://zeit.co/blog/micro-8",
-      "slug": "micro"
+      "url": "https://zeit.co/blog/micro-8"
     },
     {
       "name": "Mocha",
+      "slug": "mocha",
       "full_name": "mochajs/mocha",
       "description": "☕️ simple, flexible, fun javascript test framework for node.js & the browser",
       "stars": 14426,
@@ -1000,10 +1037,11 @@
       "owner_id": 8770005,
       "created_at": "2011-03-07T18:44:25.000Z",
       "url": "https://mochajs.org",
-      "slug": "mocha"
+      "icon": "mocha.svg"
     },
     {
       "name": "Keystone",
+      "slug": "keystone",
       "full_name": "keystonejs/keystone",
       "description": "node.js cms and web app framework",
       "stars": 11821,
@@ -1013,10 +1051,11 @@
       "owner_id": 6118534,
       "created_at": "2013-07-02T05:01:55.000Z",
       "url": "http://www.keystonejs.com",
-      "slug": "keystone"
+      "icon": "keystone.svg"
     },
     {
       "name": "React Static",
+      "slug": "react-static",
       "full_name": "nozzle/react-static",
       "description": "⚛️ 🚀 A progressive static-site generator for React.",
       "stars": 3176,
@@ -1025,11 +1064,11 @@
       "tags": ["react", "ssg"],
       "owner_id": 5400727,
       "created_at": "2017-09-09T22:10:32.000Z",
-      "url": "",
-      "slug": "react-static"
+      "url": ""
     },
     {
       "name": "Nest",
+      "slug": "nest",
       "full_name": "nestjs/nest",
       "description": "A progressive Node.js framework for building efficient and scalable server-side applications on top ",
       "stars": 3373,
@@ -1039,10 +1078,11 @@
       "owner_id": 28507035,
       "created_at": "2017-02-04T20:12:52.000Z",
       "url": "https://nestjs.com/",
-      "slug": "nest"
+      "icon": "nest.svg"
     },
     {
       "name": "Feathers",
+      "slug": "feathers",
       "full_name": "feathersjs/feathers",
       "description": "A REST and realtime API layer for modern applications.",
       "stars": 8270,
@@ -1052,10 +1092,11 @@
       "owner_id": 5321853,
       "created_at": "2011-10-19T22:45:16.000Z",
       "url": "https://feathersjs.com",
-      "slug": "feathers"
+      "icon": "feathers.svg"
     },
     {
       "name": "CSS Modules",
+      "slug": "css-modules",
       "full_name": "css-modules/css-modules",
       "description": "Documentation about css-modules",
       "stars": 8860,
@@ -1064,11 +1105,11 @@
       "tags": ["css-in-js"],
       "owner_id": 12612655,
       "created_at": "2015-05-25T21:54:47.000Z",
-      "url": "",
-      "slug": "css-modules"
+      "url": ""
     },
     {
       "name": "NativeScript",
+      "slug": "nativescript",
       "full_name": "NativeScript/NativeScript",
       "description": "NativeScript is an open source framework for building truly native mobile apps with JavaScript. Use ",
       "stars": 12203,
@@ -1078,10 +1119,11 @@
       "owner_id": 7392261,
       "created_at": "2015-03-01T09:47:08.000Z",
       "url": "http://www.nativescript.org",
-      "slug": "nativescript"
+      "icon": "nativescript.svg"
     },
     {
       "name": "Server.js",
+      "slug": "serverjs",
       "full_name": "franciscop/server",
       "description": ":desktop_computer: Simple and powerful server for Node.js",
       "stars": 3004,
@@ -1091,11 +1133,11 @@
       "owner_id": 2801252,
       "icon": "server.svg",
       "created_at": "2016-12-20T20:51:08.000Z",
-      "url": "https://serverjs.io/",
-      "slug": "serverjs"
+      "url": "https://serverjs.io/"
     },
     {
       "name": "Polished",
+      "slug": "polished",
       "full_name": "styled-components/polished",
       "description": "A lightweight toolset for writing styles in JavaScript ✨",
       "stars": 2994,
@@ -1104,11 +1146,11 @@
       "tags": ["css-in-js"],
       "owner_id": 20658825,
       "created_at": "2016-11-03T14:39:21.000Z",
-      "url": "https://polished.js.org/",
-      "slug": "polished"
+      "url": "https://polished.js.org/"
     },
     {
       "name": "Glamorous",
+      "slug": "glamorous",
       "full_name": "paypal/glamorous",
       "description": "💄 Maintainable CSS with React",
       "stars": 3036,
@@ -1117,11 +1159,11 @@
       "tags": ["css-in-js"],
       "owner_id": 476675,
       "created_at": "2017-04-03T21:35:49.000Z",
-      "url": "https://glamorous.rocks",
-      "slug": "glamorous"
+      "url": "https://glamorous.rocks"
     },
     {
       "name": "GraphQL",
+      "slug": "graphql",
       "full_name": "facebook/graphql",
       "description": "GraphQL is a query language and execution engine tied to any backend service.",
       "stars": 7095,
@@ -1131,11 +1173,11 @@
       "owner_id": 69631,
       "icon": "graphql.svg",
       "created_at": "2015-07-01T01:26:56.000Z",
-      "url": "http://facebook.github.io/graphql/",
-      "slug": "graphql"
+      "url": "http://facebook.github.io/graphql/"
     },
     {
       "name": "Poi",
+      "slug": "poi",
       "full_name": "egoist/poi",
       "description": ":zap: Delightful web development.",
       "stars": 3129,
@@ -1145,10 +1187,11 @@
       "owner_id": 8784712,
       "created_at": "2016-04-21T16:21:09.000Z",
       "url": "https://poi.js.org",
-      "slug": "poi"
+      "icon": "poi.png"
     },
     {
       "name": "Rax",
+      "slug": "rax",
       "full_name": "alibaba/rax",
       "description": ":tophat: A universal React-compatible render engine.",
       "stars": 3897,
@@ -1158,10 +1201,11 @@
       "owner_id": 1961952,
       "created_at": "2016-10-14T07:53:50.000Z",
       "url": "https://alibaba.github.io/rax",
-      "slug": "rax"
+      "icon": "rax.svg"
     },
     {
       "name": "Meteor",
+      "slug": "meteor",
       "full_name": "meteor/meteor",
       "description": "Meteor, the JavaScript App Platform",
       "stars": 39046,
@@ -1171,10 +1215,11 @@
       "owner_id": 789528,
       "created_at": "2012-01-19T01:58:17.000Z",
       "url": "https://www.meteor.com",
-      "slug": "meteor"
+      "icon": "meteor.svg"
     },
     {
       "name": "GraphiQL",
+      "slug": "graphiql",
       "full_name": "graphql/graphiql",
       "description": "An in-browser IDE for exploring GraphQL.",
       "stars": 4826,
@@ -1183,11 +1228,11 @@
       "tags": ["graphql"],
       "owner_id": 12972006,
       "created_at": "2015-08-11T02:56:22.000Z",
-      "url": "",
-      "slug": "graphiql"
+      "url": ""
     },
     {
       "name": "FuseBox",
+      "slug": "fusebox",
       "full_name": "fuse-box/fuse-box",
       "description": "A blazing fast js bundler/loader with a comprehensive API :fire:",
       "stars": 3123,
@@ -1196,11 +1241,11 @@
       "tags": ["module", "build"],
       "owner_id": 23119087,
       "created_at": "2016-10-28T10:37:16.000Z",
-      "url": "http://fuse-box.org",
-      "slug": "fusebox"
+      "url": "http://fuse-box.org"
     },
     {
       "name": "Emotion",
+      "slug": "emotion",
       "full_name": "emotion-js/emotion",
       "description": "⚡️ The Next Generation of CSS-in-JS",
       "stars": 2704,
@@ -1209,11 +1254,11 @@
       "tags": ["css-in-js"],
       "owner_id": 31557565,
       "created_at": "2017-05-27T04:23:45.000Z",
-      "url": "https://emotion.sh/",
-      "slug": "emotion"
+      "url": "https://emotion.sh/"
     },
     {
       "name": "Relay",
+      "slug": "relay",
       "full_name": "facebook/relay",
       "description": "Relay is a JavaScript framework for building data-driven React applications.",
       "stars": 10348,
@@ -1223,11 +1268,11 @@
       "owner_id": 69631,
       "icon": "relay.svg",
       "created_at": "2015-08-10T22:09:16.000Z",
-      "url": "https://facebook.github.io/relay/",
-      "slug": "relay"
+      "url": "https://facebook.github.io/relay/"
     },
     {
       "name": "Apollo Server",
+      "slug": "apollo-server",
       "full_name": "apollographql/apollo-server",
       "description": ":earth_africa: GraphQL server for Express, Connect, Hapi, Koa and more",
       "stars": 3021,
@@ -1237,10 +1282,11 @@
       "owner_id": 17189275,
       "created_at": "2016-04-21T09:26:01.000Z",
       "url": "https://www.apollographql.com/docs/apollo-server/",
-      "slug": "apollo-server"
+      "icon": "apollo.svg"
     },
     {
       "name": "Reason",
+      "slug": "reason",
       "full_name": "facebook/reason",
       "description": "Simple, fast & type safe code that leverages the JavaScript & OCaml ecosystems",
       "stars": 4742,
@@ -1250,10 +1296,11 @@
       "owner_id": 69631,
       "created_at": "2015-11-16T08:22:32.000Z",
       "url": "http://reasonml.github.io",
-      "slug": "reason"
+      "icon": "reason.svg"
     },
     {
       "name": "Brackets",
+      "slug": "brackets",
       "full_name": "adobe/brackets",
       "description": "An open source code editor for the web, written in JavaScript, HTML and CSS.",
       "stars": 28597,
@@ -1263,10 +1310,11 @@
       "owner_id": 476009,
       "created_at": "2011-12-07T21:14:40.000Z",
       "url": "http://brackets.io",
-      "slug": "brackets"
+      "icon": "brackets.svg"
     },
     {
       "name": "Styled JSX",
+      "slug": "styled-jsx",
       "full_name": "zeit/styled-jsx",
       "description": "Full CSS support for JSX without compromises",
       "stars": 2653,
@@ -1275,8 +1323,7 @@
       "tags": ["css-in-js"],
       "owner_id": 14985020,
       "created_at": "2016-12-05T13:58:02.000Z",
-      "url": "",
-      "slug": "styled-jsx"
+      "url": ""
     },
     {
       "name": "Graphcool",
@@ -1289,10 +1336,12 @@
       "tags": ["graphql"],
       "owner_id": 17219288,
       "created_at": "2016-09-25T12:54:40.000Z",
-      "url": "https://www.prismagraphql.com"
+      "url": "https://www.prismagraphql.com",
+      "icon": "prisma.svg"
     },
     {
       "name": "Aphrodite",
+      "slug": "aphrodite",
       "full_name": "Khan/aphrodite",
       "description": "Framework-agnostic CSS-in-JS with support for server-side rendering, browser prefixing, and minimum ",
       "stars": 3825,
@@ -1301,11 +1350,11 @@
       "tags": ["css-in-js"],
       "owner_id": 15455,
       "created_at": "2015-10-07T02:31:35.000Z",
-      "url": "",
-      "slug": "aphrodite"
+      "url": ""
     },
     {
       "name": "Nuclide",
+      "slug": "nuclide",
       "full_name": "facebook/nuclide",
       "description": "An open IDE for web and native mobile development, built on top of Atom ",
       "stars": 7383,
@@ -1315,11 +1364,11 @@
       "owner_id": 69631,
       "icon": "nuclide.svg",
       "created_at": "2015-03-02T05:25:27.000Z",
-      "url": "https://nuclide.io",
-      "slug": "nuclide"
+      "url": "https://nuclide.io"
     },
     {
       "name": "Phenomic",
+      "slug": "phenomic",
       "full_name": "phenomic/phenomic",
       "description": "Modular website compiler ⚡️",
       "stars": 2793,
@@ -1328,11 +1377,11 @@
       "tags": ["ssg", "react"],
       "owner_id": 28756976,
       "created_at": "2015-09-01T09:40:57.000Z",
-      "url": "https://phenomic.io/",
-      "slug": "phenomic"
+      "url": "https://phenomic.io/"
     },
     {
       "name": "Vulcan",
+      "slug": "vulcan",
       "full_name": "VulcanJS/Vulcan",
       "description": "🌋 A toolkit to quickly build apps with React, GraphQL & Meteor",
       "stars": 6497,
@@ -1341,11 +1390,11 @@
       "tags": ["realtime", "meteor", "graphql", "nodejs-framework"],
       "owner_id": 6634779,
       "created_at": "2012-09-07T01:13:24.000Z",
-      "url": "http://vulcanjs.org",
-      "slug": "vulcan"
+      "url": "http://vulcanjs.org"
     },
     {
       "name": "Glamor",
+      "slug": "glamor",
       "full_name": "threepointone/glamor",
       "description": "inline css for react et al",
       "stars": 2859,
@@ -1354,11 +1403,11 @@
       "tags": ["css-in-js"],
       "owner_id": 18808,
       "created_at": "2016-07-18T11:25:39.000Z",
-      "url": "",
-      "slug": "glamor"
+      "url": ""
     },
     {
       "name": "JSS",
+      "slug": "jss",
       "full_name": "cssinjs/jss",
       "description": "JSS is an authoring tool for CSS which uses JavaScript as a host language.",
       "stars": 3020,
@@ -1367,11 +1416,11 @@
       "tags": ["css-in-js"],
       "owner_id": 9503099,
       "created_at": "2014-10-12T20:33:53.000Z",
-      "url": "http://cssinjs.org",
-      "slug": "jss"
+      "url": "http://cssinjs.org"
     },
     {
       "name": "GraphQL Playground",
+      "slug": "graphql-playground",
       "full_name": "graphcool/graphql-playground",
       "description": "🎮  GraphQL IDE for better development workflows (GraphQL Subscriptions, interactive docs & collabor",
       "stars": 1381,
@@ -1380,11 +1429,11 @@
       "tags": ["graphql"],
       "owner_id": 17219288,
       "created_at": "2017-01-25T13:19:29.000Z",
-      "url": "",
-      "slug": "graphql-playground"
+      "url": ""
     },
     {
       "name": "Purescript",
+      "slug": "purescript",
       "full_name": "purescript/purescript",
       "description": "A strongly-typed language that compiles to Javascript",
       "stars": 4402,
@@ -1393,11 +1442,11 @@
       "tags": ["compiler"],
       "owner_id": 6556677,
       "created_at": "2013-09-30T05:29:23.000Z",
-      "url": "http://purescript.org",
-      "slug": "purescript"
+      "url": "http://purescript.org"
     },
     {
       "name": "Radium",
+      "slug": "radium",
       "full_name": "FormidableLabs/radium",
       "description": "A toolchain for React component styling.",
       "stars": 5974,
@@ -1406,11 +1455,11 @@
       "tags": ["css-in-js"],
       "owner_id": 5078602,
       "created_at": "2015-01-09T19:35:59.000Z",
-      "url": "http://formidable.com/open-source/radium/",
-      "slug": "radium"
+      "url": "http://formidable.com/open-source/radium/"
     },
     {
       "name": "Jasmine",
+      "slug": "jasmine",
       "full_name": "jasmine/jasmine",
       "description": "Simple JavaScript testing framework for browsers and node.js",
       "stars": 13209,
@@ -1420,10 +1469,11 @@
       "owner_id": 4624349,
       "created_at": "2008-12-02T23:46:37.000Z",
       "url": "http://jasmine.github.io/",
-      "slug": "jasmine"
+      "icon": "jasmine.svg"
     },
     {
       "name": "Browserify",
+      "slug": "browserify",
       "full_name": "browserify/browserify",
       "description": "browser-side require() the node.js way",
       "stars": 11699,
@@ -1433,10 +1483,11 @@
       "owner_id": 6320506,
       "created_at": "2010-09-22T16:11:32.000Z",
       "url": "http://browserify.org/",
-      "slug": "browserify"
+      "icon": "browserify.svg"
     },
     {
       "name": "ClojureScript",
+      "slug": "clojurescript",
       "full_name": "clojure/clojurescript",
       "description": "Clojure to JS compiler",
       "stars": 7483,
@@ -1446,10 +1497,11 @@
       "owner_id": 317875,
       "created_at": "2011-07-20T23:29:13.000Z",
       "url": "http://clojurescript.org/",
-      "slug": "clojurescript"
+      "icon": "clojure.svg"
     },
     {
       "name": "Metalsmith",
+      "slug": "metalsmith",
       "full_name": "segmentio/metalsmith",
       "description": "An extremely simple, pluggable static site generator.",
       "stars": 6510,
@@ -1458,11 +1510,11 @@
       "tags": ["ssg"],
       "owner_id": 819518,
       "created_at": "2014-02-04T03:46:22.000Z",
-      "url": "http://metalsmith.io",
-      "slug": "metalsmith"
+      "url": "http://metalsmith.io"
     },
     {
       "name": "Tape",
+      "slug": "tape",
       "full_name": "substack/tape",
       "description": "tap-producing test harness for node and browsers",
       "stars": 4367,
@@ -1471,11 +1523,11 @@
       "tags": ["test-framework", "test"],
       "owner_id": 12631,
       "created_at": "2012-11-25T17:08:02.000Z",
-      "url": "",
-      "slug": "tape"
+      "url": ""
     },
     {
       "name": "CoffeeScript",
+      "slug": "coffeescript",
       "full_name": "jashkenas/coffeescript",
       "description": "Unfancy JavaScript",
       "stars": 14520,
@@ -1485,11 +1537,11 @@
       "owner_id": 4732,
       "icon": "coffeescript.svg",
       "created_at": "2009-12-18T01:39:53.000Z",
-      "url": "http://coffeescript.org/",
-      "slug": "coffeescript"
+      "url": "http://coffeescript.org/"
     },
     {
       "name": "Elm",
+      "slug": "elm",
       "full_name": "elm-lang/elm-compiler",
       "description": "Compiler for Elm, a functional language for reliable webapps.",
       "stars": 4305,
@@ -1499,7 +1551,7 @@
       "owner_id": 4359353,
       "created_at": "2012-04-19T06:24:43.000Z",
       "url": "http://elm-lang.org/",
-      "slug": "elm"
+      "icon": "elm.svg"
     }
   ],
   "tags": [

--- a/data/2018/projects.json
+++ b/data/2018/projects.json
@@ -2,6 +2,7 @@
   "projects": [
     {
       "name": "Vue.js",
+      "slug": "vuejs",
       "full_name": "vuejs/vue",
       "description": "🖖 Vue.js is a progressive, incrementally-adoptable JavaScript framework for building UI on the web.",
       "stars": 124137,
@@ -13,11 +14,11 @@
       "owner_id": 6128107,
       "icon": "vue.svg",
       "created_at": "2013-07-29T03:24:51.000Z",
-      "url": "http://vuejs.org",
-      "slug": "vuejs"
+      "url": "http://vuejs.org"
     },
     {
       "name": "JS Algorithms & Data Structures",
+      "slug": "js-algorithms-and-data-structures",
       "full_name": "trekhleb/javascript-algorithms",
       "description": "📝 Algorithms and data structures implemented in JavaScript with explanations and links to further r",
       "stars": 41938,
@@ -26,11 +27,11 @@
       "tags": ["learning", "data-structure"],
       "owner_id": 3000285,
       "created_at": "2018-03-24T07:47:04.000Z",
-      "url": "",
-      "slug": "js-algorithms-and-data-structures"
+      "url": ""
     },
     {
       "name": "React",
+      "slug": "react",
       "full_name": "facebook/react",
       "description": "A declarative, efficient, and flexible JavaScript library for building user interfaces.",
       "stars": 119154,
@@ -42,11 +43,11 @@
       "owner_id": 69631,
       "icon": "react.svg",
       "created_at": "2013-05-24T16:15:54.000Z",
-      "url": "https://reactjs.org",
-      "slug": "react"
+      "url": "https://reactjs.org"
     },
     {
       "name": "VS Code",
+      "slug": "vs-code",
       "full_name": "Microsoft/vscode",
       "description": "Visual Studio Code",
       "stars": 66818,
@@ -58,11 +59,11 @@
       "owner_id": 6154722,
       "icon": "vscode.svg",
       "created_at": "2015-09-03T20:23:38.000Z",
-      "url": "https://code.visualstudio.com",
-      "slug": "vs-code"
+      "url": "https://code.visualstudio.com"
     },
     {
       "name": "30 seconds of code",
+      "slug": "30-seconds-of-code",
       "full_name": "30-seconds/30-seconds-of-code",
       "description": "Curated collection of useful JavaScript snippets that you can understand in 30 seconds or less.",
       "stars": 35950,
@@ -73,11 +74,11 @@
       "tags": ["learning"],
       "owner_id": 43479428,
       "created_at": "2017-11-29T17:35:03.000Z",
-      "url": "https://30secondsofcode.org/",
-      "slug": "30-seconds-of-code"
+      "url": "https://30secondsofcode.org/"
     },
     {
       "name": "Deno",
+      "slug": "deno",
       "full_name": "denoland/deno",
       "description": "A secure TypeScript runtime on V8",
       "stars": 28926,
@@ -87,10 +88,11 @@
       "owner_id": 42048915,
       "created_at": "2018-05-15T01:34:26.000Z",
       "url": "https://deno.land/",
-      "slug": "deno"
+      "icon": "deno.svg"
     },
     {
       "name": "Puppeteer",
+      "slug": "puppeteer",
       "full_name": "GoogleChrome/puppeteer",
       "description": "Headless Chrome Node API",
       "stars": 43549,
@@ -102,10 +104,11 @@
       "owner_id": 1778935,
       "created_at": "2017-05-09T22:16:13.000Z",
       "url": "https://pptr.dev",
-      "slug": "puppeteer"
+      "icon": "puppeteer.svg"
     },
     {
       "name": "Create React App",
+      "slug": "create-react-app",
       "full_name": "facebook/create-react-app",
       "description": "Set up a modern web app by running one command.",
       "stars": 61640,
@@ -117,10 +120,11 @@
       "owner_id": 69631,
       "created_at": "2016-07-17T14:55:11.000Z",
       "url": "https://facebook.github.io/create-react-app/",
-      "slug": "create-react-app"
+      "icon": "cra.svg"
     },
     {
       "name": "You Don't Know JS",
+      "slug": "you-dont-know-js",
       "full_name": "getify/You-Dont-Know-JS",
       "description": "A book series on JavaScript. @YDKJS on twitter.",
       "stars": 94170,
@@ -132,11 +136,11 @@
       "owner_id": 150330,
       "icon": "js.svg",
       "created_at": "2013-11-16T02:37:24.000Z",
-      "url": "http://www.kickstarter.com/projects/getify/you-dont-know-js-book-series",
-      "slug": "you-dont-know-js"
+      "url": "http://www.kickstarter.com/projects/getify/you-dont-know-js-book-series"
     },
     {
       "name": "Axios",
+      "slug": "axios",
       "full_name": "axios/axios",
       "description": "Promise based HTTP client for the browser and node.js",
       "stars": 53288,
@@ -148,10 +152,11 @@
       "owner_id": 32372333,
       "created_at": "2014-08-18T22:30:27.000Z",
       "url": "",
-      "slug": "axios"
+      "icon": "axios.svg"
     },
     {
       "name": "Ant Design",
+      "slug": "ant-design",
       "full_name": "ant-design/ant-design",
       "description": "🐜 A UI Design Language",
       "stars": 40706,
@@ -163,10 +168,11 @@
       "owner_id": 12101536,
       "created_at": "2015-04-24T15:37:24.000Z",
       "url": "https://ant.design",
-      "slug": "ant-design"
+      "icon": "ant.svg"
     },
     {
       "name": "Vue Element Admin",
+      "slug": "vue-element-admin",
       "full_name": "PanJiaChen/vue-element-admin",
       "description": "A magical vue admin",
       "stars": 25080,
@@ -178,11 +184,11 @@
       "owner_id": 8121621,
       "icon": "vueelementadmin.png",
       "created_at": "2017-04-17T03:35:49.000Z",
-      "url": "http://panjiachen.github.io/vue-element-admin",
-      "slug": "vue-element-admin"
+      "url": "http://panjiachen.github.io/vue-element-admin"
     },
     {
       "name": "Airbnb Style Guide",
+      "slug": "airbnb-style-guide",
       "full_name": "airbnb/javascript",
       "description": "JavaScript Style Guide",
       "stars": 80277,
@@ -193,11 +199,11 @@
       "tags": ["learning"],
       "owner_id": 698437,
       "created_at": "2012-11-01T23:13:50.000Z",
-      "url": "",
-      "slug": "airbnb-style-guide"
+      "url": ""
     },
     {
       "name": "Storybook",
+      "slug": "storybook",
       "full_name": "storybooks/storybook",
       "description": "Interactive UI component dev & test: React, React Native, Vue, Angular, Ember",
       "stars": 32616,
@@ -209,10 +215,11 @@
       "owner_id": 22632046,
       "created_at": "2016-03-18T04:23:44.000Z",
       "url": "https://storybook.js.org",
-      "slug": "storybook"
+      "icon": "storybook.svg"
     },
     {
       "name": "Parcel",
+      "slug": "parcel",
       "full_name": "parcel-bundler/parcel",
       "description": "📦🚀 Blazing fast, zero configuration web application bundler",
       "stars": 28953,
@@ -224,10 +231,11 @@
       "owner_id": 32607881,
       "created_at": "2017-08-07T16:36:47.000Z",
       "url": "https://parceljs.org",
-      "slug": "parcel"
+      "icon": "parcel.svg"
     },
     {
       "name": "Day.js",
+      "slug": "dayjs",
       "full_name": "iamkun/dayjs",
       "description": "⏰ Day.js 2KB immutable date library alternative to Moment.js with the same modern API",
       "stars": 17680,
@@ -236,11 +244,11 @@
       "tags": ["date"],
       "owner_id": 17680888,
       "created_at": "2018-04-10T09:26:44.000Z",
-      "url": "https://github.com/iamkun/dayjs",
-      "slug": "dayjs"
+      "url": "https://github.com/iamkun/dayjs"
     },
     {
       "name": "React Native",
+      "slug": "react-native",
       "full_name": "facebook/react-native",
       "description": "A framework for building native apps with React.",
       "stars": 72595,
@@ -252,11 +260,11 @@
       "owner_id": 69631,
       "icon": "react-native.svg",
       "created_at": "2015-01-09T18:10:16.000Z",
-      "url": "https://facebook.github.io/react-native/",
-      "slug": "react-native"
+      "url": "https://facebook.github.io/react-native/"
     },
     {
       "name": "Electron",
+      "slug": "electron",
       "full_name": "electron/electron",
       "description": ":electron: Build cross-platform desktop apps with JavaScript, HTML, and CSS",
       "stars": 68435,
@@ -268,10 +276,11 @@
       "owner_id": 13409222,
       "created_at": "2013-04-12T01:47:36.000Z",
       "url": "https://electronjs.org",
-      "slug": "electron"
+      "icon": "electron.svg"
     },
     {
       "name": "TypeScript",
+      "slug": "typescript",
       "full_name": "Microsoft/TypeScript",
       "description": "TypeScript is a superset of JavaScript that compiles to clean JavaScript output.",
       "stars": 43248,
@@ -283,11 +292,11 @@
       "owner_id": 6154722,
       "icon": "typescript.svg",
       "created_at": "2014-06-17T15:28:39.000Z",
-      "url": "http://www.typescriptlang.org",
-      "slug": "typescript"
+      "url": "http://www.typescriptlang.org"
     },
     {
       "name": "Gatsby",
+      "slug": "gatsby",
       "full_name": "gatsbyjs/gatsby",
       "description": "Build blazing fast, modern apps and websites with React",
       "stars": 29790,
@@ -299,11 +308,11 @@
       "owner_id": 12551863,
       "icon": "gatsby.svg",
       "created_at": "2015-05-21T22:43:05.000Z",
-      "url": "https://www.gatsbyjs.org",
-      "slug": "gatsby"
+      "url": "https://www.gatsbyjs.org"
     },
     {
       "name": "Node.js",
+      "slug": "nodejs",
       "full_name": "nodejs/node",
       "description": "Node.js JavaScript runtime :sparkles::turtle::rocket::sparkles:",
       "stars": 57007,
@@ -315,10 +324,11 @@
       "owner_id": 9950313,
       "created_at": "2014-11-26T19:57:11.000Z",
       "url": "https://nodejs.org",
-      "slug": "nodejs"
+      "icon": "nodejs.svg"
     },
     {
       "name": "Next.js",
+      "slug": "nextjs",
       "full_name": "zeit/next.js",
       "description": "The React Framework",
       "stars": 33219,
@@ -330,11 +340,11 @@
       "owner_id": 14985020,
       "icon": "nextjs.svg",
       "created_at": "2016-10-05T23:32:51.000Z",
-      "url": "https://nextjs.org",
-      "slug": "nextjs"
+      "url": "https://nextjs.org"
     },
     {
       "name": "Angular",
+      "slug": "angular",
       "full_name": "angular/angular",
       "description": "One framework. Mobile & desktop.",
       "stars": 44062,
@@ -346,11 +356,11 @@
       "owner_id": 139426,
       "icon": "angular.svg",
       "created_at": "2014-09-18T16:12:01.000Z",
-      "url": "https://angular.io",
-      "slug": "angular"
+      "url": "https://angular.io"
     },
     {
       "name": "Element",
+      "slug": "element",
       "full_name": "ElemeFE/element",
       "description": "A Vue.js 2.0 UI Toolkit for Web",
       "stars": 34031,
@@ -362,10 +372,11 @@
       "owner_id": 12810740,
       "created_at": "2016-09-03T06:19:26.000Z",
       "url": "https://element.eleme.io/",
-      "slug": "element"
+      "icon": "element.svg"
     },
     {
       "name": "Material UI",
+      "slug": "material-ui",
       "full_name": "mui-org/material-ui",
       "description": "React components that implement Google's Material Design.",
       "stars": 43318,
@@ -375,10 +386,11 @@
       "owner_id": 33663932,
       "created_at": "2014-08-18T19:11:54.000Z",
       "url": "https://material-ui.com/",
-      "slug": "material-ui"
+      "icon": "material-ui.svg"
     },
     {
       "name": "Webpack",
+      "slug": "webpack",
       "full_name": "webpack/webpack",
       "description": "A bundler for javascript and friends. Packs many modules into a few bundled assets. Code Splitting a",
       "stars": 46253,
@@ -390,11 +402,11 @@
       "owner_id": 2105791,
       "icon": "webpack.svg",
       "created_at": "2012-03-10T10:08:14.000Z",
-      "url": "https://webpack.js.org",
-      "slug": "webpack"
+      "url": "https://webpack.js.org"
     },
     {
       "name": "Prettier",
+      "slug": "prettier",
       "full_name": "prettier/prettier",
       "description": "Prettier is an opinionated code formatter.",
       "stars": 29500,
@@ -404,11 +416,11 @@
       "owner_id": 25822731,
       "icon": "prettier.svg",
       "created_at": "2016-11-29T17:13:37.000Z",
-      "url": "https://prettier.io",
-      "slug": "prettier"
+      "url": "https://prettier.io"
     },
     {
       "name": "VuePress",
+      "slug": "vuepress",
       "full_name": "vuejs/vuepress",
       "description": "📝 Minimalistic Vue-powered static site generator",
       "stars": 10647,
@@ -417,11 +429,11 @@
       "tags": ["vue", "ssg"],
       "owner_id": 6128107,
       "created_at": "2018-04-05T16:58:38.000Z",
-      "url": "https://vuepress.vuejs.org/",
-      "slug": "vuepress"
+      "url": "https://vuepress.vuejs.org/"
     },
     {
       "name": "Tabler",
+      "slug": "tabler",
       "full_name": "tabler/tabler",
       "description": "Tabler is free and open-source HTML Dashboard UI Kit built on Bootstrap 4",
       "stars": 16823,
@@ -430,11 +442,11 @@
       "tags": ["html", "dashboard"],
       "owner_id": 35471246,
       "created_at": "2018-02-01T09:08:59.000Z",
-      "url": "https://tabler.io/",
-      "slug": "tabler"
+      "url": "https://tabler.io/"
     },
     {
       "name": "Node.js Best Practices",
+      "slug": "nodejs-best-practices",
       "full_name": "i0natan/nodebestpractices",
       "description": "The largest Node.js best practices list (January 2019)",
       "stars": 22213,
@@ -445,11 +457,11 @@
       "tags": ["learning"],
       "owner_id": 8571500,
       "created_at": "2017-09-15T08:33:19.000Z",
-      "url": "https://twitter.com/nodepractices/",
-      "slug": "nodejs-best-practices"
+      "url": "https://twitter.com/nodepractices/"
     },
     {
       "name": "33 JS Concepts",
+      "slug": "33-js-concepts",
       "full_name": "leonardomso/33-js-concepts",
       "description": "📜 33 concepts every JavaScript developer should know.",
       "stars": 23774,
@@ -458,11 +470,11 @@
       "tags": ["learning"],
       "owner_id": 8030067,
       "created_at": "2018-09-04T13:27:04.000Z",
-      "url": "",
-      "slug": "33-js-concepts"
+      "url": ""
     },
     {
       "name": "D3",
+      "slug": "d3",
       "full_name": "d3/d3",
       "description": "Bring data to life with SVG, Canvas and HTML. :bar_chart::chart_with_upwards_trend::tada:",
       "stars": 81489,
@@ -472,10 +484,11 @@
       "owner_id": 1562726,
       "created_at": "2010-09-27T17:22:42.000Z",
       "url": "https://d3js.org",
-      "slug": "d3"
+      "icon": "d3.svg"
     },
     {
       "name": "Bootstrap",
+      "slug": "bootstrap",
       "full_name": "twbs/bootstrap",
       "description": "The most popular HTML, CSS, and JavaScript framework for developing responsive, mobile first project",
       "stars": 129834,
@@ -485,10 +498,11 @@
       "owner_id": 2918581,
       "created_at": "2011-07-29T21:19:00.000Z",
       "url": "https://getbootstrap.com",
-      "slug": "bootstrap"
+      "icon": "bootstrap.svg"
     },
     {
       "name": "vue-cli",
+      "slug": "vue-cli",
       "full_name": "vuejs/vue-cli",
       "description": "🛠️ Standard Tooling for Vue.js Development",
       "stars": 18252,
@@ -499,11 +513,11 @@
       "tags": ["vue"],
       "owner_id": 6128107,
       "created_at": "2015-12-26T23:11:20.000Z",
-      "url": "https://cli.vuejs.org/",
-      "slug": "vue-cli"
+      "url": "https://cli.vuejs.org/"
     },
     {
       "name": "ReLaXed",
+      "slug": "relaxed",
       "full_name": "RelaxedJS/ReLaXed",
       "description": "Create PDF documents using web technologies",
       "stars": 10533,
@@ -512,11 +526,11 @@
       "tags": ["pdf"],
       "owner_id": 37601651,
       "created_at": "2018-03-21T08:33:48.000Z",
-      "url": "",
-      "slug": "relaxed"
+      "url": ""
     },
     {
       "name": "Three.js",
+      "slug": "threejs",
       "full_name": "mrdoob/three.js",
       "description": "JavaScript 3D library.",
       "stars": 47811,
@@ -526,10 +540,11 @@
       "owner_id": 97088,
       "created_at": "2010-03-23T18:58:01.000Z",
       "url": "https://threejs.org/",
-      "slug": "threejs"
+      "icon": "threejs.svg"
     },
     {
       "name": "Ant Design Pro",
+      "slug": "ant-design-pro",
       "full_name": "ant-design/ant-design-pro",
       "description": "👨🏻‍💻👩🏻‍💻 Use Ant Design like a Pro!",
       "stars": 15335,
@@ -539,10 +554,11 @@
       "owner_id": 12101536,
       "created_at": "2017-08-25T10:40:44.000Z",
       "url": "http://pro.ant.design/",
-      "slug": "ant-design-pro"
+      "icon": "ant.svg"
     },
     {
       "name": "json-server",
+      "slug": "json-server",
       "full_name": "typicode/json-server",
       "description": "Get a full fake REST API with zero coding in less than 30 seconds (seriously)",
       "stars": 37265,
@@ -551,11 +567,11 @@
       "tags": ["test", "filesystem"],
       "owner_id": 5502029,
       "created_at": "2013-11-27T13:21:13.000Z",
-      "url": "",
-      "slug": "json-server"
+      "url": ""
     },
     {
       "name": "Docz",
+      "slug": "docz",
       "full_name": "pedronauck/docz",
       "description": "✍🏻It has never been so easy to document your things!",
       "stars": 12488,
@@ -563,13 +579,13 @@
       "monthly": [595, 487, 517, 1092, 2117, 1486, 2863],
       "tags": ["react", "doc"],
       "owner_id": 2029172,
-      "icon": "docz.png",
+      "icon": "docz.svg",
       "created_at": "2018-03-17T04:24:10.000Z",
-      "url": "https://docz.site",
-      "slug": "docz"
+      "url": "https://docz.site"
     },
     {
       "name": "Tech Interview Handbook",
+      "slug": "tech-interview-handbook",
       "full_name": "yangshun/tech-interview-handbook",
       "description": "💯 Algorithms study materials, behavioral content and tips for rocking your coding interview",
       "stars": 25021,
@@ -581,10 +597,11 @@
       "owner_id": 1315101,
       "created_at": "2016-07-05T05:00:48.000Z",
       "url": "",
-      "slug": "tech-interview-handbook"
+      "icon": "tech-interview.svg"
     },
     {
       "name": "Redux",
+      "slug": "redux",
       "full_name": "reduxjs/redux",
       "description": "Predictable state container for JavaScript apps",
       "stars": 46117,
@@ -594,11 +611,11 @@
       "owner_id": 13142323,
       "icon": "redux.svg",
       "created_at": "2015-05-29T23:53:15.000Z",
-      "url": "http://redux.js.org",
-      "slug": "redux"
+      "url": "http://redux.js.org"
     },
     {
       "name": "Styled Components",
+      "slug": "styled-components",
       "full_name": "styled-components/styled-components",
       "description": "Visual primitives for the component age. Use the best bits of ES6 and CSS to style your apps without",
       "stars": 21306,
@@ -607,11 +624,11 @@
       "tags": ["css-in-js"],
       "owner_id": 20658825,
       "created_at": "2016-08-16T06:41:32.000Z",
-      "url": "https://styled-components.com",
-      "slug": "styled-components"
+      "url": "https://styled-components.com"
     },
     {
       "name": "Bulma",
+      "slug": "bulma",
       "full_name": "jgthms/bulma",
       "description": "Modern CSS framework based on Flexbox",
       "stars": 32162,
@@ -621,11 +638,11 @@
       "owner_id": 1254808,
       "icon": "bulma.svg",
       "created_at": "2016-01-23T23:48:34.000Z",
-      "url": "https://bulma.io",
-      "slug": "bulma"
+      "url": "https://bulma.io"
     },
     {
       "name": "Echarts",
+      "slug": "echarts",
       "full_name": "apache/incubator-echarts",
       "description": "A powerful, interactive charting and visualization library for browser",
       "stars": 31975,
@@ -634,11 +651,11 @@
       "tags": ["chart"],
       "owner_id": 47359,
       "created_at": "2013-04-03T03:18:59.000Z",
-      "url": "http://echarts.baidu.com/",
-      "slug": "echarts"
+      "url": "http://echarts.baidu.com/"
     },
     {
       "name": "Popmotion",
+      "slug": "popmotion",
       "full_name": "Popmotion/popmotion",
       "description": "Simple animation libraries for delightful user interfaces",
       "stars": 15856,
@@ -649,11 +666,11 @@
       "tags": ["animation"],
       "owner_id": 14272617,
       "created_at": "2014-08-17T16:23:07.000Z",
-      "url": "https://popmotion.io",
-      "slug": "popmotion"
+      "url": "https://popmotion.io"
     },
     {
       "name": "Nuxt",
+      "slug": "nuxt",
       "full_name": "nuxt/nuxt.js",
       "description": "The Vue.js Developers Framework",
       "stars": 17288,
@@ -663,11 +680,11 @@
       "owner_id": 23360933,
       "icon": "nuxt.svg",
       "created_at": "2016-10-26T11:18:47.000Z",
-      "url": "https://nuxtjs.org",
-      "slug": "nuxt"
+      "url": "https://nuxtjs.org"
     },
     {
       "name": "30 Seconds of CSS",
+      "slug": "30-seconds-of-css",
       "full_name": "30-seconds/30-seconds-of-css",
       "description": "A curated collection of useful CSS snippets you can understand in 30 seconds or less.",
       "stars": 11047,
@@ -676,11 +693,11 @@
       "tags": ["learning"],
       "owner_id": 43479428,
       "created_at": "2018-02-25T13:22:25.000Z",
-      "url": "https://30-seconds.github.io/30-seconds-of-css/",
-      "slug": "30-seconds-of-css"
+      "url": "https://30-seconds.github.io/30-seconds-of-css/"
     },
     {
       "name": "Animate.css",
+      "slug": "animatecss",
       "full_name": "daneden/animate.css",
       "description": "🍿 A cross-browser library of CSS animations. As easy to use as an easy thing.",
       "stars": 56598,
@@ -689,11 +706,11 @@
       "tags": ["animation"],
       "owner_id": 439365,
       "created_at": "2011-10-12T10:07:38.000Z",
-      "url": "http://daneden.github.io/animate.css",
-      "slug": "animatecss"
+      "url": "http://daneden.github.io/animate.css"
     },
     {
       "name": "Front-End Checklist",
+      "slug": "front-end-checklist",
       "full_name": "thedaviddias/Front-End-Checklist",
       "description": "🗂 The perfect Front-End Checklist for modern websites and meticulous developers",
       "stars": 32801,
@@ -703,11 +720,11 @@
       "owner_id": 237229,
       "icon": "frontendchecklist.jpg",
       "created_at": "2017-10-16T10:12:36.000Z",
-      "url": "https://frontendchecklist.io",
-      "slug": "front-end-checklist"
+      "url": "https://frontendchecklist.io"
     },
     {
       "name": "Nest",
+      "slug": "nest",
       "full_name": "nestjs/nest",
       "description": "A progressive Node.js framework for building efficient and scalable server-side applications on top ",
       "stars": 11473,
@@ -717,10 +734,11 @@
       "owner_id": 28507035,
       "created_at": "2017-02-04T20:12:52.000Z",
       "url": "https://nestjs.com/",
-      "slug": "nest"
+      "icon": "nest.svg"
     },
     {
       "name": "Vuetify",
+      "slug": "vuetify",
       "full_name": "vuetifyjs/vuetify",
       "description": "🐉 Material Component Framework for Vue.js 2",
       "stars": 15774,
@@ -730,10 +748,11 @@
       "owner_id": 22138497,
       "created_at": "2016-09-12T00:39:35.000Z",
       "url": "https://vuetifyjs.com",
-      "slug": "vuetify"
+      "icon": "vuetify.svg"
     },
     {
       "name": "Jest",
+      "slug": "jest",
       "full_name": "facebook/jest",
       "description": "Delightful JavaScript Testing.",
       "stars": 22616,
@@ -743,11 +762,11 @@
       "owner_id": 69631,
       "icon": "jest.svg",
       "created_at": "2013-12-10T00:18:04.000Z",
-      "url": "https://jestjs.io",
-      "slug": "jest"
+      "url": "https://jestjs.io"
     },
     {
       "name": "Prisma",
+      "slug": "prisma",
       "full_name": "prisma/prisma",
       "description": "⚡️ Prisma enables seamless type-safe database access & declarative data modeling",
       "stars": 12013,
@@ -757,10 +776,11 @@
       "owner_id": 17219288,
       "created_at": "2016-09-25T12:54:40.000Z",
       "url": "https://www.prisma.io",
-      "slug": "prisma"
+      "icon": "prisma.svg"
     },
     {
       "name": "Lodash",
+      "slug": "lodash",
       "full_name": "lodash/lodash",
       "description": "A modern JavaScript utility library delivering modularity, performance, & extras.",
       "stars": 36648,
@@ -770,10 +790,11 @@
       "owner_id": 2565403,
       "created_at": "2012-04-07T04:11:46.000Z",
       "url": "https://lodash.com/",
-      "slug": "lodash"
+      "icon": "lodash.svg"
     },
     {
       "name": "Strapi",
+      "slug": "strapi",
       "full_name": "strapi/strapi",
       "description": "🚀 Open source Node.js Headless CMS to easily build customisable APIs",
       "stars": 10536,
@@ -783,10 +804,11 @@
       "owner_id": 19872173,
       "created_at": "2015-09-30T15:34:48.000Z",
       "url": "https://strapi.io",
-      "slug": "strapi"
+      "icon": "strapi.svg"
     },
     {
       "name": "Formik",
+      "slug": "formik",
       "full_name": "jaredpalmer/formik",
       "description": "Build forms in React, without the tears 😭 ",
       "stars": 12076,
@@ -796,11 +818,11 @@
       "owner_id": 4060187,
       "icon": "formik.svg",
       "created_at": "2017-06-14T19:50:59.000Z",
-      "url": "https://jaredpalmer.com/formik",
-      "slug": "formik"
+      "url": "https://jaredpalmer.com/formik"
     },
     {
       "name": "Project Guidelines",
+      "slug": "project-guidelines",
       "full_name": "elsewhencode/project-guidelines",
       "description": "A set of best practices for JavaScript projects",
       "stars": 19153,
@@ -809,11 +831,11 @@
       "tags": ["learning"],
       "owner_id": 7815827,
       "created_at": "2017-06-30T10:17:55.000Z",
-      "url": "",
-      "slug": "project-guidelines"
+      "url": ""
     },
     {
       "name": "Hyperapp",
+      "slug": "hyperapp",
       "full_name": "jorgebucaran/hyperapp",
       "description": "1 kB JavaScript micro-framework for building declarative web applications",
       "stars": 15964,
@@ -823,11 +845,11 @@
       "owner_id": 56996,
       "icon": "hyperapp.svg",
       "created_at": "2017-01-20T05:20:21.000Z",
-      "url": "",
-      "slug": "hyperapp"
+      "url": ""
     },
     {
       "name": "react-beautiful-dnd",
+      "slug": "react-beautiful-dnd",
       "full_name": "atlassian/react-beautiful-dnd",
       "description": "Beautiful and accessible drag and drop for lists with React",
       "stars": 12088,
@@ -837,10 +859,11 @@
       "owner_id": 168166,
       "created_at": "2017-08-09T03:37:15.000Z",
       "url": "",
-      "slug": "react-beautiful-dnd"
+      "icon": "rbd.svg"
     },
     {
       "name": "Uppy",
+      "slug": "uppy",
       "full_name": "transloadit/uppy",
       "description": "The next open source file uploader for web browsers :dog: ",
       "stars": 12632,
@@ -850,10 +873,11 @@
       "owner_id": 125754,
       "created_at": "2015-11-16T12:32:33.000Z",
       "url": "https://uppy.io",
-      "slug": "uppy"
+      "icon": "uppy.svg"
     },
     {
       "name": "iView",
+      "slug": "iview",
       "full_name": "iview/iview",
       "description": "A high quality UI Toolkit built on Vue.js 2.0",
       "stars": 19209,
@@ -863,10 +887,11 @@
       "owner_id": 20693613,
       "created_at": "2016-07-28T01:52:59.000Z",
       "url": "https://iviewui.com/",
-      "slug": "iview"
+      "icon": "iview.svg"
     },
     {
       "name": "Docusaurus",
+      "slug": "docusaurus",
       "full_name": "facebook/Docusaurus",
       "description": "Easy to maintain open source documentation websites.",
       "stars": 10152,
@@ -876,11 +901,11 @@
       "owner_id": 69631,
       "icon": "docusaurus.svg",
       "created_at": "2017-06-20T16:13:53.000Z",
-      "url": "https://docusaurus.io",
-      "slug": "docusaurus"
+      "url": "https://docusaurus.io"
     },
     {
       "name": "react-loadable",
+      "slug": "react-loadable",
       "full_name": "jamiebuilds/react-loadable",
       "description": ":hourglass_flowing_sand: A higher order component for loading components with promises.",
       "stars": 11996,
@@ -889,11 +914,11 @@
       "tags": ["isomorphic", "react"],
       "owner_id": 952783,
       "created_at": "2017-03-09T18:41:17.000Z",
-      "url": "",
-      "slug": "react-loadable"
+      "url": ""
     },
     {
       "name": "React Router",
+      "slug": "react-router",
       "full_name": "ReactTraining/react-router",
       "description": "Declarative routing for React",
       "stars": 34234,
@@ -903,10 +928,11 @@
       "owner_id": 11823761,
       "created_at": "2014-05-16T22:22:51.000Z",
       "url": "https://reacttraining.com/react-router/",
-      "slug": "react-router"
+      "icon": "react-router.svg"
     },
     {
       "name": "Vuex",
+      "slug": "vuex",
       "full_name": "vuejs/vuex",
       "description": "🗃️ Centralized State Management for Vue.js.",
       "stars": 18456,
@@ -915,11 +941,11 @@
       "tags": ["flux", "vue", "state"],
       "owner_id": 6128107,
       "created_at": "2015-07-16T04:21:26.000Z",
-      "url": "https://vuex.vuejs.org",
-      "slug": "vuex"
+      "url": "https://vuex.vuejs.org"
     },
     {
       "name": "Babel",
+      "slug": "babel",
       "full_name": "babel/babel",
       "description": "🐠 Babel is a compiler for writing next generation JavaScript.",
       "stars": 31322,
@@ -929,10 +955,11 @@
       "owner_id": 9637642,
       "created_at": "2014-09-28T13:38:23.000Z",
       "url": "https://babeljs.io/",
-      "slug": "babel"
+      "icon": "babel.svg"
     },
     {
       "name": "React-spring",
+      "slug": "react-spring",
       "full_name": "react-spring/react-spring",
       "description": "✌️ A spring physics based React animation library",
       "stars": 9215,
@@ -941,11 +968,11 @@
       "tags": ["react", "animation"],
       "owner_id": 45790596,
       "created_at": "2018-03-07T15:39:32.000Z",
-      "url": "https://react-spring.github.io",
-      "slug": "react-spring"
+      "url": "https://react-spring.github.io"
     },
     {
       "name": "Evergreen",
+      "slug": "evergreen",
       "full_name": "segmentio/evergreen",
       "description": "🌲 Evergreen React UI Framework by Segment",
       "stars": 6869,
@@ -954,11 +981,11 @@
       "tags": ["react", "component"],
       "owner_id": 819518,
       "created_at": "2017-07-30T10:03:14.000Z",
-      "url": "https://evergreen.segment.com/",
-      "slug": "evergreen"
+      "url": "https://evergreen.segment.com/"
     },
     {
       "name": "Angular CLI",
+      "slug": "angular-cli",
       "full_name": "angular/angular-cli",
       "description": "CLI tool for Angular",
       "stars": 20709,
@@ -967,11 +994,11 @@
       "tags": ["angular", "scaffolding"],
       "owner_id": 139426,
       "created_at": "2015-06-04T19:49:37.000Z",
-      "url": "https://cli.angular.io/",
-      "slug": "angular-cli"
+      "url": "https://cli.angular.io/"
     },
     {
       "name": "Express",
+      "slug": "express",
       "full_name": "expressjs/express",
       "description": "Fast, unopinionated, minimalist web framework for node.",
       "stars": 41788,
@@ -981,10 +1008,11 @@
       "owner_id": 5658226,
       "created_at": "2009-06-26T18:56:01.000Z",
       "url": "https://expressjs.com",
-      "slug": "express"
+      "icon": "express.svg"
     },
     {
       "name": "mdx-deck",
+      "slug": "mdx-deck",
       "full_name": "jxnblk/mdx-deck",
       "description": ":spades: MDX-based presentation decks",
       "stars": 5984,
@@ -993,11 +1021,11 @@
       "tags": ["presentation", "md", "react"],
       "owner_id": 3451712,
       "created_at": "2018-07-28T22:36:10.000Z",
-      "url": "https://jxnblk.com/mdx-deck",
-      "slug": "mdx-deck"
+      "url": "https://jxnblk.com/mdx-deck"
     },
     {
       "name": "React Navigation",
+      "slug": "react-navigation",
       "full_name": "react-navigation/react-navigation",
       "description": "Routing and navigation for your React Native apps",
       "stars": 14359,
@@ -1006,11 +1034,11 @@
       "tags": ["routing", "react-native"],
       "owner_id": 29647600,
       "created_at": "2017-01-26T19:51:40.000Z",
-      "url": "https://reactnavigation.org",
-      "slug": "react-navigation"
+      "url": "https://reactnavigation.org"
     },
     {
       "name": "react virtualized",
+      "slug": "react-virtualized",
       "full_name": "bvaughn/react-virtualized",
       "description": "React components for efficiently rendering large lists and tabular data",
       "stars": 13880,
@@ -1019,11 +1047,11 @@
       "tags": ["react", "scrolling"],
       "owner_id": 29597,
       "created_at": "2015-11-03T00:48:07.000Z",
-      "url": "http://www.reactvirtualized.com",
-      "slug": "react-virtualized"
+      "url": "http://www.reactvirtualized.com"
     },
     {
       "name": "Koa",
+      "slug": "koa",
       "full_name": "koajs/koa",
       "description": "Expressive middleware for node.js using ES2017 async functions",
       "stars": 24521,
@@ -1032,11 +1060,11 @@
       "tags": ["nodejs-framework"],
       "owner_id": 5055057,
       "created_at": "2013-07-20T18:53:45.000Z",
-      "url": "https://koajs.com",
-      "slug": "koa"
+      "url": "https://koajs.com"
     },
     {
       "name": "Omi",
+      "slug": "omi",
       "full_name": "Tencent/omi",
       "description": "Next generation web framework using web components with omio fallback(IE8+) in tiny js. ",
       "stars": 6727,
@@ -1046,11 +1074,11 @@
       "owner_id": 18461506,
       "icon": "omi.svg",
       "created_at": "2015-05-31T14:24:58.000Z",
-      "url": "http://omijs.org",
-      "slug": "omi"
+      "url": "http://omijs.org"
     },
     {
       "name": "React-select",
+      "slug": "react-select",
       "full_name": "JedWatson/react-select",
       "description": "The Select Component for React.js",
       "stars": 15055,
@@ -1059,11 +1087,11 @@
       "tags": ["autocomplete", "react"],
       "owner_id": 872310,
       "created_at": "2014-08-26T04:27:45.000Z",
-      "url": "https://react-select.com/",
-      "slug": "react-select"
+      "url": "https://react-select.com/"
     },
     {
       "name": "Blueprint",
+      "slug": "blueprint",
       "full_name": "palantir/blueprint",
       "description": "A React-based UI toolkit for the web",
       "stars": 12911,
@@ -1073,10 +1101,11 @@
       "owner_id": 303157,
       "created_at": "2016-10-25T21:17:50.000Z",
       "url": "https://blueprintjs.com/",
-      "slug": "blueprint"
+      "icon": "blueprint.svg"
     },
     {
       "name": "Egg",
+      "slug": "egg",
       "full_name": "eggjs/egg",
       "description": "🥚 Born to build better enterprise frameworks and apps with Node.js & Koa",
       "stars": 11244,
@@ -1085,11 +1114,11 @@
       "tags": ["nodejs-framework"],
       "owner_id": 15833670,
       "created_at": "2016-06-18T06:53:23.000Z",
-      "url": "https://eggjs.org",
-      "slug": "egg"
+      "url": "https://eggjs.org"
     },
     {
       "name": "Atom",
+      "slug": "atom",
       "full_name": "atom/atom",
       "description": ":atom: The hackable text editor",
       "stars": 47478,
@@ -1099,10 +1128,11 @@
       "owner_id": 1089146,
       "created_at": "2012-01-20T18:18:21.000Z",
       "url": "https://atom.io",
-      "slug": "atom"
+      "icon": "atom.svg"
     },
     {
       "name": "ngx-admin",
+      "slug": "ngx-admin",
       "full_name": "akveo/ngx-admin",
       "description": "Admin dashboard template based on Angular 7+, Bootstrap 4 (previously known as ng2-admin)",
       "stars": 14650,
@@ -1111,11 +1141,11 @@
       "tags": ["angular", "dashboard"],
       "owner_id": 11921694,
       "created_at": "2016-05-25T10:09:03.000Z",
-      "url": "http://akveo.com/ngx-admin/",
-      "slug": "ngx-admin"
+      "url": "http://akveo.com/ngx-admin/"
     },
     {
       "name": "Hexo",
+      "slug": "hexo",
       "full_name": "hexojs/hexo",
       "description": "A fast, simple & powerful blog framework, powered by Node.js.",
       "stars": 24814,
@@ -1125,10 +1155,11 @@
       "owner_id": 6375567,
       "created_at": "2012-09-23T15:17:08.000Z",
       "url": "https://hexo.io",
-      "slug": "hexo"
+      "icon": "hexo.svg"
     },
     {
       "name": "dva",
+      "slug": "dva",
       "full_name": "dvajs/dva",
       "description": "🌱 React and redux based, lightweight and elm-style framework. (Inspired by elm and choo)",
       "stars": 12067,
@@ -1137,11 +1168,11 @@
       "tags": ["framework", "redux"],
       "owner_id": 20552239,
       "created_at": "2016-06-24T09:06:16.000Z",
-      "url": "https://dvajs.com/",
-      "slug": "dva"
+      "url": "https://dvajs.com/"
     },
     {
       "name": "Recompose",
+      "slug": "recompose",
       "full_name": "acdlite/recompose",
       "description": "A React utility belt for function components and higher-order components.",
       "stars": 13128,
@@ -1150,11 +1181,11 @@
       "tags": ["react", "fp"],
       "owner_id": 3624098,
       "created_at": "2015-10-07T05:54:51.000Z",
-      "url": "",
-      "slug": "recompose"
+      "url": ""
     },
     {
       "name": "Weex",
+      "slug": "weex",
       "full_name": "apache/incubator-weex",
       "description": "A framework for building Mobile cross-platform UI.",
       "stars": 11482,
@@ -1164,11 +1195,11 @@
       "owner_id": 47359,
       "icon": "weex.svg",
       "created_at": "2017-01-06T08:00:06.000Z",
-      "url": "https://weex.apache.org",
-      "slug": "weex"
+      "url": "https://weex.apache.org"
     },
     {
       "name": "Material Design for Angular",
+      "slug": "material-design-for-angular",
       "full_name": "angular/material2",
       "description": "Material Design components for Angular",
       "stars": 16901,
@@ -1177,11 +1208,11 @@
       "tags": ["material", "angular"],
       "owner_id": 139426,
       "created_at": "2016-01-04T18:50:02.000Z",
-      "url": "https://material.angular.io",
-      "slug": "material-design-for-angular"
+      "url": "https://material.angular.io"
     },
     {
       "name": "Preact",
+      "slug": "preact",
       "full_name": "developit/preact",
       "description": "⚛️ Fast 3kB React alternative with the same modern API. Components & Virtual DOM.",
       "stars": 21219,
@@ -1191,11 +1222,11 @@
       "owner_id": 105127,
       "icon": "preact.svg",
       "created_at": "2015-09-11T02:40:18.000Z",
-      "url": "https://preactjs.com",
-      "slug": "preact"
+      "url": "https://preactjs.com"
     },
     {
       "name": "Apollo client",
+      "slug": "apollo-client",
       "full_name": "apollographql/apollo-client",
       "description": ":rocket: A fully-featured, production ready caching GraphQL client for every UI framework and GraphQ",
       "stars": 9635,
@@ -1205,10 +1236,11 @@
       "owner_id": 17189275,
       "created_at": "2016-02-26T20:25:00.000Z",
       "url": "http://dev.apollodata.com/",
-      "slug": "apollo-client"
+      "icon": "apollo.svg"
     },
     {
       "name": "vux",
+      "slug": "vux",
       "full_name": "airyland/vux",
       "description": "Mobile UI Components based on Vue & WeUI",
       "stars": 14896,
@@ -1217,11 +1249,11 @@
       "tags": ["vue"],
       "owner_id": 559179,
       "created_at": "2016-02-15T03:23:27.000Z",
-      "url": "https://vux.li/",
-      "slug": "vux"
+      "url": "https://vux.li/"
     },
     {
       "name": "Emotion",
+      "slug": "emotion",
       "full_name": "emotion-js/emotion",
       "description": "CSS-in-JS library designed for high performance style composition",
       "stars": 6539,
@@ -1230,11 +1262,11 @@
       "tags": ["css-in-js"],
       "owner_id": 31557565,
       "created_at": "2017-05-27T04:23:45.000Z",
-      "url": "https://emotion.sh/",
-      "slug": "emotion"
+      "url": "https://emotion.sh/"
     },
     {
       "name": "Flow",
+      "slug": "flow",
       "full_name": "facebook/flow",
       "description": "Adds static typing to JavaScript to improve developer productivity and code quality.",
       "stars": 18671,
@@ -1244,11 +1276,11 @@
       "owner_id": 69631,
       "icon": "flow.svg",
       "created_at": "2014-10-28T17:17:45.000Z",
-      "url": "https://flow.org/",
-      "slug": "flow"
+      "url": "https://flow.org/"
     },
     {
       "name": "NativeScript",
+      "slug": "nativescript",
       "full_name": "NativeScript/NativeScript",
       "description": "NativeScript is an open source framework for building truly native mobile apps with JavaScript. Use ",
       "stars": 15856,
@@ -1258,10 +1290,11 @@
       "owner_id": 7392261,
       "created_at": "2015-03-01T09:47:08.000Z",
       "url": "https://www.nativescript.org",
-      "slug": "nativescript"
+      "icon": "nativescript.svg"
     },
     {
       "name": "GraphQL",
+      "slug": "graphql",
       "full_name": "facebook/graphql",
       "description": "GraphQL is a query language and execution engine tied to any backend service.",
       "stars": 10611,
@@ -1271,11 +1304,11 @@
       "owner_id": 69631,
       "icon": "graphql.svg",
       "created_at": "2015-07-01T01:26:56.000Z",
-      "url": "https://graphql.org/",
-      "slug": "graphql"
+      "url": "https://graphql.org/"
     },
     {
       "name": "Quasar",
+      "slug": "quasar",
       "full_name": "quasarframework/quasar",
       "description": "Quasar Framework",
       "stars": 8204,
@@ -1285,10 +1318,11 @@
       "owner_id": 23064371,
       "created_at": "2015-10-05T15:45:36.000Z",
       "url": "https://quasar-framework.org",
-      "slug": "quasar"
+      "icon": "quasar.svg"
     },
     {
       "name": "Nerv",
+      "slug": "nerv",
       "full_name": "NervJS/nerv",
       "description": "A blazing fast React alternative, compatible with IE8 and React 16.",
       "stars": 4514,
@@ -1297,11 +1331,11 @@
       "tags": ["framework", "vdom"],
       "owner_id": 30794937,
       "created_at": "2017-05-07T17:20:01.000Z",
-      "url": "https://nerv.aotu.io",
-      "slug": "nerv"
+      "url": "https://nerv.aotu.io"
     },
     {
       "name": "Ionic",
+      "slug": "ionic",
       "full_name": "ionic-team/ionic",
       "description": "Build amazing native and progressive web apps with open web technologies. One app running on everyth",
       "stars": 36326,
@@ -1311,10 +1345,11 @@
       "owner_id": 3171503,
       "created_at": "2013-08-20T23:06:02.000Z",
       "url": "https://ionicframework.com/",
-      "slug": "ionic"
+      "icon": "ionic.svg"
     },
     {
       "name": "Fastify",
+      "slug": "fastify",
       "full_name": "fastify/fastify",
       "description": "Fast and low overhead web framework, for Node.js",
       "stars": 9216,
@@ -1324,10 +1359,11 @@
       "owner_id": 24939410,
       "created_at": "2016-09-28T19:10:14.000Z",
       "url": "https://www.fastify.io",
-      "slug": "fastify"
+      "icon": "fastify.svg"
     },
     {
       "name": "React Static",
+      "slug": "react-static",
       "full_name": "nozzle/react-static",
       "description": "⚛️ 🚀 A progressive static site generator for React.",
       "stars": 6345,
@@ -1336,11 +1372,11 @@
       "tags": ["react", "ssg"],
       "owner_id": 5400727,
       "created_at": "2017-09-09T22:10:32.000Z",
-      "url": "https://react-static.js.org",
-      "slug": "react-static"
+      "url": "https://react-static.js.org"
     },
     {
       "name": "umi",
+      "slug": "umi",
       "full_name": "umijs/umi",
       "description": "🌋 Pluggable enterprise-level react application framework.",
       "stars": 3330,
@@ -1349,11 +1385,11 @@
       "tags": ["nodejs-framework", "react"],
       "owner_id": 33895495,
       "created_at": "2017-11-22T10:09:36.000Z",
-      "url": "https://umijs.org/",
-      "slug": "umi"
+      "url": "https://umijs.org/"
     },
     {
       "name": "Apollo Server",
+      "slug": "apollo-server",
       "full_name": "apollographql/apollo-server",
       "description": "🌍 GraphQL server for Express, Connect, Hapi, Koa and more",
       "stars": 6052,
@@ -1363,10 +1399,11 @@
       "owner_id": 17189275,
       "created_at": "2016-04-21T09:26:01.000Z",
       "url": "https://www.apollographql.com/docs/apollo-server/",
-      "slug": "apollo-server"
+      "icon": "apollo.svg"
     },
     {
       "name": "Rollup",
+      "slug": "rollup",
       "full_name": "rollup/rollup",
       "description": "Next-generation ES module bundler",
       "stars": 14576,
@@ -1376,10 +1413,11 @@
       "owner_id": 12554859,
       "created_at": "2015-05-14T22:26:28.000Z",
       "url": "https://rollupjs.org",
-      "slug": "rollup"
+      "icon": "rollup.svg"
     },
     {
       "name": "AVA",
+      "slug": "ava",
       "full_name": "avajs/ava",
       "description": "🚀 Testing can be a drag. AVA helps you get it done.",
       "stars": 15468,
@@ -1389,10 +1427,11 @@
       "owner_id": 8527916,
       "created_at": "2014-11-18T17:20:26.000Z",
       "url": "",
-      "slug": "ava"
+      "icon": "ava.svg"
     },
     {
       "name": "Svelte",
+      "slug": "svelte",
       "full_name": "sveltejs/svelte",
       "description": "The magical disappearing UI framework",
       "stars": 8752,
@@ -1402,10 +1441,11 @@
       "owner_id": 23617963,
       "created_at": "2016-11-20T18:13:05.000Z",
       "url": "https://svelte.technology",
-      "slug": "svelte"
+      "icon": "svelte.svg"
     },
     {
       "name": "Stencil",
+      "slug": "stencil",
       "full_name": "ionic-team/stencil",
       "description": "A Web Component compiler for building fast, reusable UI components and Progressive Web Apps 💎 Built",
       "stars": 4623,
@@ -1415,10 +1455,11 @@
       "owner_id": 3171503,
       "created_at": "2017-02-15T18:57:07.000Z",
       "url": "https://stenciljs.com/",
-      "slug": "stencil"
+      "icon": "stencil.svg"
     },
     {
       "name": "Reason",
+      "slug": "reason",
       "full_name": "facebook/reason",
       "description": "Simple, fast & type safe code that leverages the JavaScript & OCaml ecosystems",
       "stars": 7044,
@@ -1428,11 +1469,11 @@
       "owner_id": 69631,
       "icon": "reason.svg",
       "created_at": "2015-11-16T08:22:32.000Z",
-      "url": "http://reasonml.github.io",
-      "slug": "reason"
+      "url": "http://reasonml.github.io"
     },
     {
       "name": "GraphiQL",
+      "slug": "graphiql",
       "full_name": "graphql/graphiql",
       "description": "An in-browser IDE for exploring GraphQL.",
       "stars": 7385,
@@ -1441,11 +1482,11 @@
       "tags": ["graphql"],
       "owner_id": 12972006,
       "created_at": "2015-08-11T02:56:22.000Z",
-      "url": "",
-      "slug": "graphiql"
+      "url": ""
     },
     {
       "name": "Mocha",
+      "slug": "mocha",
       "full_name": "mochajs/mocha",
       "description": "☕️ simple, flexible, fun javascript test framework for node.js & the browser",
       "stars": 16928,
@@ -1455,10 +1496,11 @@
       "owner_id": 8770005,
       "created_at": "2011-03-07T18:44:25.000Z",
       "url": "https://mochajs.org",
-      "slug": "mocha"
+      "icon": "mocha.svg"
     },
     {
       "name": "Hasura GraphQL Engine",
+      "slug": "hasura-graphql-engine",
       "full_name": "hasura/graphql-engine",
       "description": "Blazing fast, instant realtime GraphQL APIs on Postgres with fine grained access control, also trigg",
       "stars": 5780,
@@ -1468,10 +1510,11 @@
       "owner_id": 13966722,
       "created_at": "2018-06-18T07:57:36.000Z",
       "url": "https://hasura.io",
-      "slug": "hasura-graphql-engine"
+      "icon": "hasura.svg"
     },
     {
       "name": "Gulp",
+      "slug": "gulp",
       "full_name": "gulpjs/gulp",
       "description": "The streaming build system",
       "stars": 30774,
@@ -1481,10 +1524,11 @@
       "owner_id": 6200624,
       "created_at": "2013-07-04T05:26:06.000Z",
       "url": "http://gulpjs.com",
-      "slug": "gulp"
+      "icon": "gulp.svg"
     },
     {
       "name": "CSS Modules",
+      "slug": "css-modules",
       "full_name": "css-modules/css-modules",
       "description": "Documentation about css-modules",
       "stars": 11195,
@@ -1493,11 +1537,11 @@
       "tags": ["css-in-js"],
       "owner_id": 12612655,
       "created_at": "2015-05-25T21:54:47.000Z",
-      "url": "",
-      "slug": "css-modules"
+      "url": ""
     },
     {
       "name": "NgRx",
+      "slug": "ngrx",
       "full_name": "ngrx/platform",
       "description": "Reactive libraries for Angular",
       "stars": 4220,
@@ -1506,11 +1550,11 @@
       "tags": ["angular", "reactive", "state"],
       "owner_id": 16272733,
       "created_at": "2017-03-02T19:34:15.000Z",
-      "url": "https://ngrx.io",
-      "slug": "ngrx"
+      "url": "https://ngrx.io"
     },
     {
       "name": "Gun",
+      "slug": "gun",
       "full_name": "amark/gun",
       "description": "A realtime, decentralized, offline-first, mutable graph database engine.",
       "stars": 9443,
@@ -1520,11 +1564,11 @@
       "owner_id": 433412,
       "icon": "gun.svg",
       "created_at": "2014-07-31T15:52:10.000Z",
-      "url": "https://gun.eco/docs",
-      "slug": "gun"
+      "url": "https://gun.eco/docs"
     },
     {
       "name": "Canner",
+      "slug": "canner",
       "full_name": "Canner/canner",
       "description": "⚡️CMS for developers, a flexible CMS create CMS fast and easy. Support data sources such as Firebase",
       "stars": 2318,
@@ -1533,11 +1577,11 @@
       "tags": ["cms", "graphql"],
       "owner_id": 7250217,
       "created_at": "2018-03-01T04:42:17.000Z",
-      "url": "https://www.cannercms.com",
-      "slug": "canner"
+      "url": "https://www.cannercms.com"
     },
     {
       "name": "React Starter Kit",
+      "slug": "react-starter-kit",
       "full_name": "kriasoft/react-starter-kit",
       "description": "React Starter Kit — isomorphic web app boilerplate (Node.js, Express, GraphQL, React.js, Babel, Post",
       "stars": 18677,
@@ -1546,11 +1590,11 @@
       "tags": ["react", "isomorphic", "boilerplate", "graphql"],
       "owner_id": 773036,
       "created_at": "2014-04-16T13:08:18.000Z",
-      "url": "https://reactstarter.com",
-      "slug": "react-starter-kit"
+      "url": "https://reactstarter.com"
     },
     {
       "name": "GraphQL Playground",
+      "slug": "graphql-playground",
       "full_name": "prisma/graphql-playground",
       "description": "🎮  GraphQL IDE for better development workflows (GraphQL Subscriptions, interactive docs & collabor",
       "stars": 3537,
@@ -1559,11 +1603,11 @@
       "tags": ["graphql"],
       "owner_id": 17219288,
       "created_at": "2017-01-25T13:19:29.000Z",
-      "url": "",
-      "slug": "graphql-playground"
+      "url": ""
     },
     {
       "name": "Micro",
+      "slug": "micro",
       "full_name": "zeit/micro",
       "description": "Asynchronous HTTP microservices",
       "stars": 7856,
@@ -1572,11 +1616,11 @@
       "tags": ["microservice", "nodejs-framework"],
       "owner_id": 14985020,
       "created_at": "2016-01-23T05:17:00.000Z",
-      "url": "https://zeit.co/blog/micro-8",
-      "slug": "micro"
+      "url": "https://zeit.co/blog/micro-8"
     },
     {
       "name": "NG-ZORRO",
+      "slug": "ng-zorro",
       "full_name": "NG-ZORRO/ng-zorro-antd",
       "description": "An enterprise-class UI components based on Ant Design and Angular 7. 🐜 ",
       "stars": 4251,
@@ -1585,11 +1629,11 @@
       "tags": ["angular", "component"],
       "owner_id": 30223759,
       "created_at": "2017-08-08T14:59:33.000Z",
-      "url": "https://ng.ant.design/docs/introduce/en",
-      "slug": "ng-zorro"
+      "url": "https://ng.ant.design/docs/introduce/en"
     },
     {
       "name": "Feathers",
+      "slug": "feathers",
       "full_name": "feathersjs/feathers",
       "description": "A REST and realtime API layer for modern applications.",
       "stars": 10294,
@@ -1599,10 +1643,11 @@
       "owner_id": 5321853,
       "created_at": "2011-10-19T22:45:16.000Z",
       "url": "https://feathersjs.com",
-      "slug": "feathers"
+      "icon": "feathers.svg"
     },
     {
       "name": "Keystone",
+      "slug": "keystone",
       "full_name": "keystonejs/keystone",
       "description": "Node.js CMS and web app framework",
       "stars": 13843,
@@ -1612,10 +1657,11 @@
       "owner_id": 6118534,
       "created_at": "2013-07-02T05:01:55.000Z",
       "url": "http://www.keystonejs.com",
-      "slug": "keystone"
+      "icon": "keystone.svg"
     },
     {
       "name": "Polka",
+      "slug": "polka",
       "full_name": "lukeed/polka",
       "description": "A micro web server so fast, it'll make you dance! :dancers:",
       "stars": 2784,
@@ -1624,11 +1670,11 @@
       "tags": ["nodejs-framework"],
       "owner_id": 5855893,
       "created_at": "2017-12-22T05:55:41.000Z",
-      "url": "",
-      "slug": "polka"
+      "url": ""
     },
     {
       "name": "Mithril",
+      "slug": "mithril",
       "full_name": "MithrilJS/mithril.js",
       "description": "A Javascript Framework for Building Brilliant Applications",
       "stars": 10407,
@@ -1638,11 +1684,11 @@
       "owner_id": 19475707,
       "icon": "mithril.svg",
       "created_at": "2014-03-17T01:59:39.000Z",
-      "url": "http://mithril.js.org",
-      "slug": "mithril"
+      "url": "http://mithril.js.org"
     },
     {
       "name": "Adonis",
+      "slug": "adonis",
       "full_name": "adonisjs/adonis-framework",
       "description": "NodeJs Web Application Framework. Makes it easy for you to write webapps with less code :smiley:",
       "stars": 5392,
@@ -1651,11 +1697,11 @@
       "tags": ["nodejs-framework"],
       "owner_id": 13810373,
       "created_at": "2015-08-15T17:03:54.000Z",
-      "url": "https://adonisjs.com",
-      "slug": "adonis"
+      "url": "https://adonisjs.com"
     },
     {
       "name": "After.js",
+      "slug": "afterjs",
       "full_name": "jaredpalmer/after.js",
       "description": "Next.js-like framework for server-rendered React apps built with React Router 4",
       "stars": 2912,
@@ -1664,11 +1710,11 @@
       "tags": ["nodejs-framework", "react", "isomorphic"],
       "owner_id": 4060187,
       "created_at": "2017-11-12T03:17:02.000Z",
-      "url": "",
-      "slug": "afterjs"
+      "url": ""
     },
     {
       "name": "NG Bootstrap",
+      "slug": "ng-bootstrap",
       "full_name": "ng-bootstrap/ng-bootstrap",
       "description": "Angular powered Bootstrap",
       "stars": 6427,
@@ -1677,11 +1723,11 @@
       "tags": ["angular", "component"],
       "owner_id": 14283866,
       "created_at": "2015-09-14T22:55:53.000Z",
-      "url": "https://ng-bootstrap.github.io",
-      "slug": "ng-bootstrap"
+      "url": "https://ng-bootstrap.github.io"
     },
     {
       "name": "Sails",
+      "slug": "sails",
       "full_name": "balderdashy/sails",
       "description": "Realtime MVC Framework for Node.js",
       "stars": 20082,
@@ -1689,10 +1735,9 @@
       "monthly": [118, 114, 135, 154, 141, 158, 156, 164, 274, 177, 117, 145],
       "tags": ["nodejs-framework"],
       "owner_id": 1445252,
-      "icon": "sails.jpg",
+      "icon": "sails.svg",
       "created_at": "2012-03-18T19:46:15.000Z",
-      "url": "https://sailsjs.com",
-      "slug": "sails"
+      "url": "https://sailsjs.com"
     },
     {
       "name": "Loopback",
@@ -1704,12 +1749,13 @@
       "monthly": [130, 159, 170, 156, 136, 140, 154, 167, 172, 141, 145, 173],
       "tags": ["api", "nodejs-framework"],
       "owner_id": 3020012,
-      "icon": "loopback.svg",
+      "icon": "loopback3.svg",
       "created_at": "2013-04-09T16:02:18.000Z",
       "url": "http://loopback.io"
     },
     {
       "name": "Ember",
+      "slug": "ember",
       "full_name": "emberjs/ember.js",
       "description": "Ember.js - A JavaScript framework for creating ambitious web applications",
       "stars": 20359,
@@ -1719,10 +1765,11 @@
       "owner_id": 1253363,
       "created_at": "2011-05-25T23:39:40.000Z",
       "url": "http://www.emberjs.com",
-      "slug": "ember"
+      "icon": "ember.svg"
     },
     {
       "name": "Hapi",
+      "slug": "hapi",
       "full_name": "hapijs/hapi",
       "description": "Server Framework  for Node.js",
       "stars": 10619,
@@ -1732,10 +1779,11 @@
       "owner_id": 3774533,
       "created_at": "2011-08-06T00:35:39.000Z",
       "url": "hapijs.com",
-      "slug": "hapi"
+      "icon": "hapi.svg"
     },
     {
       "name": "Meteor",
+      "slug": "meteor",
       "full_name": "meteor/meteor",
       "description": "Meteor, the JavaScript App Platform",
       "stars": 40682,
@@ -1745,10 +1793,11 @@
       "owner_id": 789528,
       "created_at": "2012-01-19T01:58:17.000Z",
       "url": "https://www.meteor.com",
-      "slug": "meteor"
+      "icon": "meteor.svg"
     },
     {
       "name": "Relay",
+      "slug": "relay",
       "full_name": "facebook/relay",
       "description": "Relay is a JavaScript framework for building data-driven React applications.",
       "stars": 11882,
@@ -1758,11 +1807,11 @@
       "owner_id": 69631,
       "icon": "relay.svg",
       "created_at": "2015-08-10T22:09:16.000Z",
-      "url": "https://facebook.github.io/relay/",
-      "slug": "relay"
+      "url": "https://facebook.github.io/relay/"
     },
     {
       "name": "Linaria",
+      "slug": "linaria",
       "full_name": "callstack/linaria",
       "description": "Zero-runtime CSS in JS library",
       "stars": 2087,
@@ -1772,10 +1821,11 @@
       "owner_id": 42239399,
       "created_at": "2017-05-23T00:52:34.000Z",
       "url": "https://linaria.now.sh",
-      "slug": "linaria"
+      "icon": "linaria.svg"
     },
     {
       "name": "urql",
+      "slug": "urql",
       "full_name": "FormidableLabs/urql",
       "description": "Universal React Query Library",
       "stars": 1766,
@@ -1784,11 +1834,11 @@
       "tags": ["graphql", "react"],
       "owner_id": 5078602,
       "created_at": "2018-01-24T01:44:42.000Z",
-      "url": "",
-      "slug": "urql"
+      "url": ""
     },
     {
       "name": "Polymer",
+      "slug": "polymer",
       "full_name": "Polymer/polymer",
       "description": "Our original Web Component library.",
       "stars": 20563,
@@ -1798,10 +1848,11 @@
       "owner_id": 2159051,
       "created_at": "2012-08-23T20:56:30.000Z",
       "url": "https://polymer-library.polymer-project.org/",
-      "slug": "polymer"
+      "icon": "polymer.svg"
     },
     {
       "name": "Angular 1",
+      "slug": "angular-1",
       "full_name": "angular/angular.js",
       "description": "AngularJS - HTML enhanced for web apps!",
       "stars": 59339,
@@ -1811,11 +1862,11 @@
       "owner_id": 139426,
       "icon": "angularjs.svg",
       "created_at": "2010-01-06T00:34:37.000Z",
-      "url": "https://angularjs.org",
-      "slug": "angular-1"
+      "url": "https://angularjs.org"
     },
     {
       "name": "Clarity Design System",
+      "slug": "clarity-design-system",
       "full_name": "vmware/clarity",
       "description": "UX guidelines, HTML/CSS framework, and Angular components working together to craft exceptional expe",
       "stars": 4410,
@@ -1824,11 +1875,11 @@
       "tags": ["angular"],
       "owner_id": 473334,
       "created_at": "2016-09-29T17:24:17.000Z",
-      "url": "http://clarity.design",
-      "slug": "clarity-design-system"
+      "url": "http://clarity.design"
     },
     {
       "name": "Polished",
+      "slug": "polished",
       "full_name": "styled-components/polished",
       "description": "A lightweight toolset for writing styles in JavaScript ✨",
       "stars": 4481,
@@ -1837,11 +1888,11 @@
       "tags": ["css-in-js"],
       "owner_id": 20658825,
       "created_at": "2016-11-03T14:39:21.000Z",
-      "url": "https://polished.js.org/",
-      "slug": "polished"
+      "url": "https://polished.js.org/"
     },
     {
       "name": "JSS",
+      "slug": "jss",
       "full_name": "cssinjs/jss",
       "description": "JSS is an authoring tool for CSS which uses JavaScript as a host language.",
       "stars": 4452,
@@ -1850,11 +1901,11 @@
       "tags": ["css-in-js"],
       "owner_id": 9503099,
       "created_at": "2014-10-12T20:33:53.000Z",
-      "url": "https://cssinjs.org",
-      "slug": "jss"
+      "url": "https://cssinjs.org"
     },
     {
       "name": "NGXS",
+      "slug": "ngxs",
       "full_name": "ngxs/store",
       "description": "🚀 NGXS - State Management for Angular ",
       "stars": 1764,
@@ -1863,11 +1914,11 @@
       "tags": ["state", "angular"],
       "owner_id": 37132593,
       "created_at": "2018-02-13T18:55:44.000Z",
-      "url": "http://ngxs.io",
-      "slug": "ngxs"
+      "url": "http://ngxs.io"
     },
     {
       "name": "GraphQL.js",
+      "slug": "graphqljs",
       "full_name": "f/graphql.js",
       "description": "A Simple and Isomorphic GraphQL Client for JavaScript",
       "stars": 1848,
@@ -1876,11 +1927,11 @@
       "tags": ["graphql"],
       "owner_id": 196477,
       "created_at": "2017-02-10T08:26:13.000Z",
-      "url": "",
-      "slug": "graphqljs"
+      "url": ""
     },
     {
       "name": "Stimulus",
+      "slug": "stimulus",
       "full_name": "stimulusjs/stimulus",
       "description": "A modest JavaScript framework for the HTML you already have",
       "stars": 6692,
@@ -1890,10 +1941,11 @@
       "owner_id": 32970053,
       "created_at": "2016-12-17T00:19:29.000Z",
       "url": "https://stimulusjs.org/",
-      "slug": "stimulus"
+      "icon": "stimulus.svg"
     },
     {
       "name": "Gridsome",
+      "slug": "gridsome",
       "full_name": "gridsome/gridsome",
       "description": "⚡️  Build super fast, modern websites with Vue.js",
       "stars": 1484,
@@ -1902,11 +1954,11 @@
       "tags": ["ssg", "vue", "graphql"],
       "owner_id": 17981963,
       "created_at": "2018-07-31T22:55:06.000Z",
-      "url": "https://gridsome.org",
-      "slug": "gridsome"
+      "url": "https://gridsome.org"
     },
     {
       "name": "Styled JSX",
+      "slug": "styled-jsx",
       "full_name": "zeit/styled-jsx",
       "description": "Full CSS support for JSX without compromises",
       "stars": 3962,
@@ -1915,11 +1967,11 @@
       "tags": ["css-in-js"],
       "owner_id": 14985020,
       "created_at": "2016-12-05T13:58:02.000Z",
-      "url": "",
-      "slug": "styled-jsx"
+      "url": ""
     },
     {
       "name": "Inferno",
+      "slug": "inferno",
       "full_name": "infernojs/inferno",
       "description": ":fire: An extremely fast, React-like JavaScript library for building modern user interfaces",
       "stars": 13354,
@@ -1929,10 +1981,11 @@
       "owner_id": 14214240,
       "created_at": "2015-02-01T22:07:38.000Z",
       "url": "http://infernojs.org",
-      "slug": "inferno"
+      "icon": "inferno.svg"
     },
     {
       "name": "PrimeNG",
+      "slug": "primeng",
       "full_name": "primefaces/primeng",
       "description": "UI Components for Angular",
       "stars": 4871,
@@ -1941,11 +1994,11 @@
       "tags": ["angular", "component"],
       "owner_id": 3494069,
       "created_at": "2016-01-16T09:23:28.000Z",
-      "url": "https://www.primefaces.org/primeng",
-      "slug": "primeng"
+      "url": "https://www.primefaces.org/primeng"
     },
     {
       "name": "Poi",
+      "slug": "poi",
       "full_name": "egoist/poi",
       "description": ":zap: A zero-config bundler for JavaScript applications.",
       "stars": 4297,
@@ -1955,11 +2008,11 @@
       "owner_id": 8784712,
       "icon": "poi.png",
       "created_at": "2016-04-21T16:21:09.000Z",
-      "url": "https://poi.js.org",
-      "slug": "poi"
+      "url": "https://poi.js.org"
     },
     {
       "name": "Restify",
+      "slug": "restify",
       "full_name": "restify/node-restify",
       "description": "The future of Node.js REST development",
       "stars": 8926,
@@ -1968,8 +2021,7 @@
       "tags": ["nodejs-framework"],
       "owner_id": 6948699,
       "created_at": "2011-04-25T21:19:26.000Z",
-      "url": "http://restify.com",
-      "slug": "restify"
+      "url": "http://restify.com"
     },
     {
       "name": "Theia",
@@ -1986,6 +2038,7 @@
     },
     {
       "name": "Cycle.js",
+      "slug": "cyclejs",
       "full_name": "cyclejs/cyclejs",
       "description": "A functional and reactive JavaScript framework for predictable code",
       "stars": 9008,
@@ -1995,10 +2048,11 @@
       "owner_id": 12686838,
       "created_at": "2014-11-07T11:28:45.000Z",
       "url": "http://cycle.js.org",
-      "slug": "cyclejs"
+      "icon": "cycle.svg"
     },
     {
       "name": "Reactide",
+      "slug": "reactide",
       "full_name": "reactide/reactide",
       "description": "Reactide is the first dedicated IDE for React web application development. http://reactide.io",
       "stars": 8532,
@@ -2007,11 +2061,11 @@
       "tags": ["ide"],
       "owner_id": 26257999,
       "created_at": "2017-03-07T18:30:34.000Z",
-      "url": "http://reactide.io",
-      "slug": "reactide"
+      "url": "http://reactide.io"
     },
     {
       "name": "ngx-datatable",
+      "slug": "ngx-datatable",
       "full_name": "swimlane/ngx-datatable",
       "description": "✨  A feature-rich yet lightweight data-table crafted for Angular",
       "stars": 3251,
@@ -2020,11 +2074,11 @@
       "tags": ["angular", "table"],
       "owner_id": 10552812,
       "created_at": "2016-05-31T19:25:47.000Z",
-      "url": "http://swimlane.github.io/ngx-datatable/",
-      "slug": "ngx-datatable"
+      "url": "http://swimlane.github.io/ngx-datatable/"
     },
     {
       "name": "Rax",
+      "slug": "rax",
       "full_name": "alibaba/rax",
       "description": "[ 🚧Work In Progress v1.0] The fastest way to build cross-container application.",
       "stars": 4874,
@@ -2034,10 +2088,11 @@
       "owner_id": 1961952,
       "created_at": "2016-10-14T07:53:50.000Z",
       "url": "https://developers.taobao.com/",
-      "slug": "rax"
+      "icon": "rax.svg"
     },
     {
       "name": "Purescript",
+      "slug": "purescript",
       "full_name": "purescript/purescript",
       "description": "A strongly-typed language that compiles to Javascript",
       "stars": 5389,
@@ -2046,11 +2101,11 @@
       "tags": ["compiler", "types"],
       "owner_id": 6556677,
       "created_at": "2013-09-30T05:29:23.000Z",
-      "url": "http://purescript.org",
-      "slug": "purescript"
+      "url": "http://purescript.org"
     },
     {
       "name": "Brackets",
+      "slug": "brackets",
       "full_name": "adobe/brackets",
       "description": "An open source code editor for the web, written in JavaScript, HTML and CSS.",
       "stars": 29485,
@@ -2060,10 +2115,11 @@
       "owner_id": 476009,
       "created_at": "2011-12-07T21:14:40.000Z",
       "url": "http://brackets.io",
-      "slug": "brackets"
+      "icon": "brackets.svg"
     },
     {
       "name": "Choo",
+      "slug": "choo",
       "full_name": "choojs/choo",
       "description": ":steam_locomotive::train: - sturdy 4kb frontend framework",
       "stars": 5857,
@@ -2072,11 +2128,11 @@
       "tags": ["framework"],
       "owner_id": 29929674,
       "created_at": "2016-05-10T17:50:35.000Z",
-      "url": "https://choo.io/",
-      "slug": "choo"
+      "url": "https://choo.io/"
     },
     {
       "name": "Jasmine",
+      "slug": "jasmine",
       "full_name": "jasmine/jasmine",
       "description": "Simple JavaScript testing framework for browsers and node.js",
       "stars": 14081,
@@ -2086,10 +2142,11 @@
       "owner_id": 4624349,
       "created_at": "2008-12-02T23:46:37.000Z",
       "url": "http://jasmine.github.io/",
-      "slug": "jasmine"
+      "icon": "jasmine.svg"
     },
     {
       "name": "Glamorous",
+      "slug": "glamorous",
       "full_name": "paypal/glamorous",
       "description": "DEPRECATED: 💄 Maintainable CSS with React",
       "stars": 3764,
@@ -2098,11 +2155,11 @@
       "tags": ["css-in-js"],
       "owner_id": 476675,
       "created_at": "2017-04-03T21:35:49.000Z",
-      "url": "https://glamorous.rocks",
-      "slug": "glamorous"
+      "url": "https://glamorous.rocks"
     },
     {
       "name": "Vulcan",
+      "slug": "vulcan",
       "full_name": "VulcanJS/Vulcan",
       "description": "🌋 A toolkit to quickly build apps with React, GraphQL & Meteor",
       "stars": 7274,
@@ -2111,11 +2168,11 @@
       "tags": ["realtime", "meteor", "graphql", "nodejs-framework"],
       "owner_id": 6634779,
       "created_at": "2012-09-07T01:13:24.000Z",
-      "url": "http://vulcanjs.org",
-      "slug": "vulcan"
+      "url": "http://vulcanjs.org"
     },
     {
       "name": "Radium",
+      "slug": "radium",
       "full_name": "FormidableLabs/radium",
       "description": "A toolchain for React component styling.",
       "stars": 6759,
@@ -2124,11 +2181,11 @@
       "tags": ["css-in-js"],
       "owner_id": 5078602,
       "created_at": "2015-01-09T19:35:59.000Z",
-      "url": "http://formidable.com/open-source/radium/",
-      "slug": "radium"
+      "url": "http://formidable.com/open-source/radium/"
     },
     {
       "name": "x0",
+      "slug": "x0",
       "full_name": "c8r/x0",
       "description": "Document & develop React components without breaking a sweat",
       "stars": 1544,
@@ -2137,11 +2194,11 @@
       "tags": ["ssg", "react"],
       "owner_id": 19245838,
       "created_at": "2017-09-13T02:00:34.000Z",
-      "url": "https://compositor.io/x0/",
-      "slug": "x0"
+      "url": "https://compositor.io/x0/"
     },
     {
       "name": "Aphrodite",
+      "slug": "aphrodite",
       "full_name": "Khan/aphrodite",
       "description": "Framework-agnostic CSS-in-JS with support for server-side rendering, browser prefixing, and minimum ",
       "stars": 4486,
@@ -2150,11 +2207,11 @@
       "tags": ["css-in-js"],
       "owner_id": 15455,
       "created_at": "2015-10-07T02:31:35.000Z",
-      "url": "",
-      "slug": "aphrodite"
+      "url": ""
     },
     {
       "name": "Saber.js",
+      "slug": "saberjs",
       "full_name": "egoist/saber.js",
       "description": "A minimalistic framework for building static website using Vue.js",
       "stars": 846,
@@ -2163,11 +2220,11 @@
       "tags": ["vue", "ssg"],
       "owner_id": 8784712,
       "created_at": "2018-05-23T16:41:21.000Z",
-      "url": "",
-      "slug": "saberjs"
+      "url": ""
     },
     {
       "name": "Metalsmith",
+      "slug": "metalsmith",
       "full_name": "segmentio/metalsmith",
       "description": "An extremely simple, pluggable static site generator.",
       "stars": 7092,
@@ -2176,11 +2233,11 @@
       "tags": ["ssg"],
       "owner_id": 819518,
       "created_at": "2014-02-04T03:46:22.000Z",
-      "url": "https://metalsmith.io",
-      "slug": "metalsmith"
+      "url": "https://metalsmith.io"
     },
     {
       "name": "Tape",
+      "slug": "tape",
       "full_name": "substack/tape",
       "description": "tap-producing test harness for node and browsers",
       "stars": 4862,
@@ -2189,8 +2246,7 @@
       "tags": ["test-framework", "test"],
       "owner_id": 12631,
       "created_at": "2012-11-25T17:08:02.000Z",
-      "url": "",
-      "slug": "tape"
+      "url": ""
     }
   ],
   "tags": [

--- a/data/2019/projects.json
+++ b/data/2019/projects.json
@@ -2,6 +2,7 @@
   "projects": [
     {
       "name": "Vue.js",
+      "slug": "vuejs",
       "full_name": "vuejs/vue",
       "description": "A progressive, incrementally-adoptable framework for building UI on the web",
       "stars": 155562,
@@ -13,11 +14,11 @@
       "owner_id": 6128107,
       "icon": "vue.svg",
       "created_at": "2013-07-29T03:24:51.000Z",
-      "url": "http://vuejs.org",
-      "slug": "vuejs"
+      "url": "http://vuejs.org"
     },
     {
       "name": "VS Code",
+      "slug": "vs-code",
       "full_name": "microsoft/vscode",
       "description": "Visual Studio Code",
       "stars": 90044,
@@ -29,11 +30,11 @@
       "owner_id": 6154722,
       "icon": "vscode.svg",
       "created_at": "2015-09-03T20:23:38.000Z",
-      "url": "https://code.visualstudio.com",
-      "slug": "vs-code"
+      "url": "https://code.visualstudio.com"
     },
     {
       "name": "React",
+      "slug": "react",
       "full_name": "facebook/react",
       "description": "A declarative, efficient, and flexible JavaScript library for building user interfaces.",
       "stars": 142251,
@@ -45,11 +46,11 @@
       "owner_id": 69631,
       "icon": "react.svg",
       "created_at": "2013-05-24T16:15:54.000Z",
-      "url": "https://reactjs.org",
-      "slug": "react"
+      "url": "https://reactjs.org"
     },
     {
       "name": "Vue Element Admin",
+      "slug": "vue-element-admin",
       "full_name": "PanJiaChen/vue-element-admin",
       "description": "A magical vue admin",
       "stars": 48069,
@@ -60,11 +61,11 @@
       "tags": ["vue", "dashboard"],
       "owner_id": 8121621,
       "icon": "vueelementadmin.png",
-      "created_at": "2017-04-17T03:35:49.000Z",
-      "slug": "vue-element-admin"
+      "created_at": "2017-04-17T03:35:49.000Z"
     },
     {
       "name": "You Don't Know JS",
+      "slug": "you-dont-know-js",
       "full_name": "getify/You-Dont-Know-JS",
       "description": "A book series on JavaScript",
       "stars": 114696,
@@ -75,11 +76,11 @@
       "tags": ["learning", "book"],
       "owner_id": 150330,
       "icon": "js.svg",
-      "created_at": "2013-11-16T02:37:24.000Z",
-      "slug": "you-dont-know-js"
+      "created_at": "2013-11-16T02:37:24.000Z"
     },
     {
       "name": "Svelte",
+      "slug": "svelte",
       "full_name": "sveltejs/svelte",
       "description": "Cybernetically enhanced web apps",
       "stars": 29406,
@@ -91,11 +92,11 @@
       "owner_id": 23617963,
       "icon": "svelte.svg",
       "created_at": "2016-11-20T18:13:05.000Z",
-      "url": "https://svelte.dev",
-      "slug": "svelte"
+      "url": "https://svelte.dev"
     },
     {
       "name": "30 seconds of code",
+      "slug": "30-seconds-of-code",
       "full_name": "30-seconds/30-seconds-of-code",
       "description": "Short JavaScript code snippets for all your development needs",
       "stars": 53794,
@@ -106,11 +107,11 @@
       "tags": ["learning"],
       "owner_id": 43479428,
       "created_at": "2017-11-29T17:35:03.000Z",
-      "url": "https://www.30secondsofcode.org/js/p/1",
-      "slug": "30-seconds-of-code"
+      "url": "https://www.30secondsofcode.org/js/p/1"
     },
     {
       "name": "JS Algorithms & Data Structures",
+      "slug": "js-algorithms-and-data-structures",
       "full_name": "trekhleb/javascript-algorithms",
       "description": "Algorithms and data structures implemented in JavaScript with explanations and links to further readings",
       "stars": 60268,
@@ -120,11 +121,11 @@
       ],
       "tags": ["learning", "data-structure"],
       "owner_id": 3000285,
-      "created_at": "2018-03-24T07:47:04.000Z",
-      "slug": "js-algorithms-and-data-structures"
+      "created_at": "2018-03-24T07:47:04.000Z"
     },
     {
       "name": "Node.js Best Practices",
+      "slug": "nodejs-best-practices",
       "full_name": "goldbergyoni/nodebestpractices",
       "description": "The largest Node.js best practices list (December 2019)",
       "stars": 38135,
@@ -134,11 +135,11 @@
       ],
       "tags": ["learning"],
       "owner_id": 8571500,
-      "created_at": "2017-09-15T08:33:19.000Z",
-      "slug": "nodejs-best-practices"
+      "created_at": "2017-09-15T08:33:19.000Z"
     },
     {
       "name": "Axios",
+      "slug": "axios",
       "full_name": "axios/axios",
       "description": "Promise based HTTP client for the browser and node.js",
       "stars": 68643,
@@ -149,10 +150,11 @@
       "tags": ["http"],
       "owner_id": 32372333,
       "created_at": "2014-08-18T22:30:27.000Z",
-      "slug": "axios"
+      "icon": "axios.svg"
     },
     {
       "name": "Ant Design",
+      "slug": "ant-design",
       "full_name": "ant-design/ant-design",
       "description": "A UI Design Language and React UI library",
       "stars": 55416,
@@ -164,11 +166,11 @@
       "owner_id": 12101536,
       "icon": "ant.svg",
       "created_at": "2015-04-24T15:37:24.000Z",
-      "url": "https://ant.design",
-      "slug": "ant-design"
+      "url": "https://ant.design"
     },
     {
       "name": "TypeScript",
+      "slug": "typescript",
       "full_name": "microsoft/TypeScript",
       "description": "A superset of JavaScript that compiles to clean JavaScript output.",
       "stars": 57222,
@@ -180,11 +182,11 @@
       "owner_id": 6154722,
       "icon": "typescript.svg",
       "created_at": "2014-06-17T15:28:39.000Z",
-      "url": "https://www.typescriptlang.org",
-      "slug": "typescript"
+      "url": "https://www.typescriptlang.org"
     },
     {
       "name": "Puppeteer",
+      "slug": "puppeteer",
       "full_name": "puppeteer/puppeteer",
       "description": "Headless Chrome Node.js API",
       "stars": 57494,
@@ -196,11 +198,11 @@
       "owner_id": 6906516,
       "icon": "puppeteer.svg",
       "created_at": "2017-05-09T22:16:13.000Z",
-      "url": "https://pptr.dev/",
-      "slug": "puppeteer"
+      "url": "https://pptr.dev/"
     },
     {
       "name": "Create React App",
+      "slug": "create-react-app",
       "full_name": "facebook/create-react-app",
       "description": "Set up a modern web app by running one command.",
       "stars": 75202,
@@ -212,11 +214,11 @@
       "owner_id": 69631,
       "icon": "cra.svg",
       "created_at": "2016-07-17T14:55:11.000Z",
-      "url": "https://create-react-app.dev",
-      "slug": "create-react-app"
+      "url": "https://create-react-app.dev"
     },
     {
       "name": "Tech Interview Handbook",
+      "slug": "tech-interview-handbook",
       "full_name": "yangshun/tech-interview-handbook",
       "description": "Materials to help you rock your next coding interview",
       "stars": 38699,
@@ -226,10 +228,11 @@
       "owner_id": 1315101,
       "created_at": "2016-07-05T05:00:48.000Z",
       "url": "https://yangshun.github.io/tech-interview-handbook/",
-      "slug": "tech-interview-handbook"
+      "icon": "tech-interview.svg"
     },
     {
       "name": "Storybook",
+      "slug": "storybook",
       "full_name": "storybookjs/storybook",
       "description": "UI component dev & test: React, Vue, Angular, React Native, Ember, Web Components & more!",
       "stars": 44739,
@@ -241,11 +244,11 @@
       "owner_id": 22632046,
       "icon": "storybook.svg",
       "created_at": "2016-03-18T04:23:44.000Z",
-      "url": "https://storybook.js.org",
-      "slug": "storybook"
+      "url": "https://storybook.js.org"
     },
     {
       "name": "Angular",
+      "slug": "angular",
       "full_name": "angular/angular",
       "description": "One framework. Mobile & desktop.",
       "stars": 56348,
@@ -257,11 +260,11 @@
       "owner_id": 139426,
       "icon": "angular.svg",
       "created_at": "2014-09-18T16:12:01.000Z",
-      "url": "https://angular.io",
-      "slug": "angular"
+      "url": "https://angular.io"
     },
     {
       "name": "Deno",
+      "slug": "deno",
       "full_name": "denoland/deno",
       "description": "A secure JavaScript and TypeScript runtime",
       "stars": 40835,
@@ -273,11 +276,11 @@
       "owner_id": 42048915,
       "icon": "deno.svg",
       "created_at": "2018-05-15T01:34:26.000Z",
-      "url": "https://deno.land/",
-      "slug": "deno"
+      "url": "https://deno.land/"
     },
     {
       "name": "Electron",
+      "slug": "electron",
       "full_name": "electron/electron",
       "description": "Build cross-platform desktop apps with JavaScript, HTML, and CSS",
       "stars": 80059,
@@ -289,11 +292,11 @@
       "owner_id": 13409222,
       "icon": "electron.svg",
       "created_at": "2013-04-12T01:47:36.000Z",
-      "url": "https://electronjs.org",
-      "slug": "electron"
+      "url": "https://electronjs.org"
     },
     {
       "name": "Gatsby",
+      "slug": "gatsby",
       "full_name": "gatsbyjs/gatsby",
       "description": "Build blazing fast, modern apps and websites with React",
       "stars": 41401,
@@ -305,11 +308,11 @@
       "owner_id": 12551863,
       "icon": "gatsby.svg",
       "created_at": "2015-05-21T22:43:05.000Z",
-      "url": "https://www.gatsbyjs.org",
-      "slug": "gatsby"
+      "url": "https://www.gatsbyjs.org"
     },
     {
       "name": "Airbnb Style Guide",
+      "slug": "airbnb-style-guide",
       "full_name": "airbnb/javascript",
       "description": "JavaScript Style Guide",
       "stars": 91798,
@@ -319,11 +322,11 @@
       ],
       "tags": ["learning"],
       "owner_id": 698437,
-      "created_at": "2012-11-01T23:13:50.000Z",
-      "slug": "airbnb-style-guide"
+      "created_at": "2012-11-01T23:13:50.000Z"
     },
     {
       "name": "Nest",
+      "slug": "nest",
       "full_name": "nestjs/nest",
       "description": "A progressive Node.js framework for building efficient, scalable, and enterprise-grade server-side applications on top of TypeScript & JavaScript (ES6, ES7, ES8)",
       "stars": 23249,
@@ -333,11 +336,11 @@
       "owner_id": 28507035,
       "icon": "nest.svg",
       "created_at": "2017-02-04T20:12:52.000Z",
-      "url": "https://nestjs.com/",
-      "slug": "nest"
+      "url": "https://nestjs.com/"
     },
     {
       "name": "React Native",
+      "slug": "react-native",
       "full_name": "facebook/react-native",
       "description": "A framework for building native apps with React.",
       "stars": 84103,
@@ -349,11 +352,11 @@
       "owner_id": 69631,
       "icon": "react-native.svg",
       "created_at": "2015-01-09T18:10:16.000Z",
-      "url": "https://facebook.github.io/react-native/",
-      "slug": "react-native"
+      "url": "https://facebook.github.io/react-native/"
     },
     {
       "name": "freeCodeCamp",
+      "slug": "freecodecamp",
       "full_name": "freeCodeCamp/freeCodeCamp",
       "description": "The https://www.freeCodeCamp.org open source codebase and curriculum. Learn to code for free together with millions of people.",
       "stars": 308088,
@@ -363,11 +366,11 @@
       ],
       "tags": ["learning"],
       "owner_id": 9892522,
-      "created_at": "2014-12-24T17:49:19.000Z",
-      "slug": "freecodecamp"
+      "created_at": "2014-12-24T17:49:19.000Z"
     },
     {
       "name": "Next.js",
+      "slug": "nextjs",
       "full_name": "zeit/next.js",
       "description": "The React Framework",
       "stars": 43976,
@@ -379,11 +382,11 @@
       "owner_id": 14985020,
       "icon": "nextjs.svg",
       "created_at": "2016-10-05T23:32:51.000Z",
-      "url": "https://nextjs.org",
-      "slug": "nextjs"
+      "url": "https://nextjs.org"
     },
     {
       "name": "Strapi",
+      "slug": "strapi",
       "full_name": "strapi/strapi",
       "description": "Open source Node.js Headless CMS to easily build customisable APIs",
       "stars": 21028,
@@ -393,11 +396,11 @@
       "owner_id": 19872173,
       "icon": "strapi.svg",
       "created_at": "2015-09-30T15:34:48.000Z",
-      "url": "https://strapi.io",
-      "slug": "strapi"
+      "url": "https://strapi.io"
     },
     {
       "name": "Material UI",
+      "slug": "material-ui",
       "full_name": "mui-org/material-ui",
       "description": "React components for faster and easier web development. Build your own design system, or start with Material Design.",
       "stars": 53603,
@@ -407,11 +410,11 @@
       "owner_id": 33663932,
       "icon": "material-ui.svg",
       "created_at": "2014-08-18T19:11:54.000Z",
-      "url": "https://material-ui.com/",
-      "slug": "material-ui"
+      "url": "https://material-ui.com/"
     },
     {
       "name": "Node.js",
+      "slug": "nodejs",
       "full_name": "nodejs/node",
       "description": "Node.js JavaScript runtime",
       "stars": 67100,
@@ -421,11 +424,11 @@
       "owner_id": 9950313,
       "icon": "nodejs.svg",
       "created_at": "2014-11-26T19:57:11.000Z",
-      "url": "https://nodejs.org/",
-      "slug": "nodejs"
+      "url": "https://nodejs.org/"
     },
     {
       "name": "Three.js",
+      "slug": "threejs",
       "full_name": "mrdoob/three.js",
       "description": "JavaScript 3D library.",
       "stars": 57821,
@@ -435,10 +438,11 @@
       "owner_id": 97088,
       "created_at": "2010-03-23T18:58:01.000Z",
       "url": "https://threejs.org/",
-      "slug": "threejs"
+      "icon": "threejs.svg"
     },
     {
       "name": "Tailwind CSS",
+      "slug": "tailwind-css",
       "full_name": "tailwindcss/tailwindcss",
       "description": "A utility-first CSS framework for rapid UI development.",
       "stars": 18488,
@@ -448,11 +452,11 @@
       "owner_id": 30317862,
       "icon": "tailwindcss.svg",
       "created_at": "2017-10-06T14:59:14.000Z",
-      "url": "https://tailwindcss.com/",
-      "slug": "tailwind-css"
+      "url": "https://tailwindcss.com/"
     },
     {
       "name": "Element",
+      "slug": "element",
       "full_name": "ElemeFE/element",
       "description": "A Vue.js 2.0 UI Toolkit for Web",
       "stars": 43450,
@@ -462,11 +466,11 @@
       "owner_id": 12810740,
       "icon": "element.svg",
       "created_at": "2016-09-03T06:19:26.000Z",
-      "url": "https://element.eleme.io/",
-      "slug": "element"
+      "url": "https://element.eleme.io/"
     },
     {
       "name": "Uppy",
+      "slug": "uppy",
       "full_name": "transloadit/uppy",
       "description": "The next open source file uploader for web browsers",
       "stars": 21684,
@@ -478,11 +482,11 @@
       "owner_id": 125754,
       "icon": "uppy.svg",
       "created_at": "2015-11-16T12:32:33.000Z",
-      "url": "https://uppy.io",
-      "slug": "uppy"
+      "url": "https://uppy.io"
     },
     {
       "name": "anime.js",
+      "slug": "animejs",
       "full_name": "juliangarnier/anime",
       "description": "JavaScript animation engine",
       "stars": 33666,
@@ -492,11 +496,11 @@
       "owner_id": 1268691,
       "icon": "anime.svg",
       "created_at": "2016-03-13T21:37:45.000Z",
-      "url": "https://animejs.com",
-      "slug": "animejs"
+      "url": "https://animejs.com"
     },
     {
       "name": "Bootstrap",
+      "slug": "bootstrap",
       "full_name": "twbs/bootstrap",
       "description": "The most popular HTML, CSS, and JavaScript framework for developing responsive, mobile first projects on the web.",
       "stars": 138094,
@@ -506,11 +510,11 @@
       "owner_id": 2918581,
       "icon": "bootstrap.svg",
       "created_at": "2011-07-29T21:19:00.000Z",
-      "url": "https://getbootstrap.com",
-      "slug": "bootstrap"
+      "url": "https://getbootstrap.com"
     },
     {
       "name": "Hasura GraphQL Engine",
+      "slug": "hasura-graphql-engine",
       "full_name": "hasura/graphql-engine",
       "description": "Blazing fast, instant realtime GraphQL APIs on Postgres with fine grained access control, also trigger webhooks on database events.",
       "stars": 13975,
@@ -520,11 +524,11 @@
       "owner_id": 13966722,
       "icon": "hasura.svg",
       "created_at": "2018-06-18T07:57:36.000Z",
-      "url": "https://hasura.io",
-      "slug": "hasura-graphql-engine"
+      "url": "https://hasura.io"
     },
     {
       "name": "Ant Design Pro",
+      "slug": "ant-design-pro",
       "full_name": "ant-design/ant-design-pro",
       "description": "Use Ant Design like a Pro!",
       "stars": 23418,
@@ -534,11 +538,11 @@
       "owner_id": 12101536,
       "icon": "ant.svg",
       "created_at": "2017-08-25T10:40:44.000Z",
-      "url": "http://pro.ant.design/",
-      "slug": "ant-design-pro"
+      "url": "http://pro.ant.design/"
     },
     {
       "name": "D3",
+      "slug": "d3",
       "full_name": "d3/d3",
       "description": "Bring data to life with SVG, Canvas and HTML.",
       "stars": 89516,
@@ -548,11 +552,11 @@
       "owner_id": 1562726,
       "icon": "d3.svg",
       "created_at": "2010-09-27T17:22:42.000Z",
-      "url": "https://d3js.org",
-      "slug": "d3"
+      "url": "https://d3js.org"
     },
     {
       "name": "Formik",
+      "slug": "formik",
       "full_name": "jaredpalmer/formik",
       "description": "Build forms in React, without the tears",
       "stars": 20003,
@@ -562,11 +566,11 @@
       "owner_id": 4060187,
       "icon": "formik.svg",
       "created_at": "2017-06-14T19:50:59.000Z",
-      "url": "https://jaredpalmer.com/formik",
-      "slug": "formik"
+      "url": "https://jaredpalmer.com/formik"
     },
     {
       "name": "Cypress",
+      "slug": "cypress",
       "full_name": "cypress-io/cypress",
       "description": "Fast, easy and reliable testing for anything that runs in a browser.",
       "stars": 17556,
@@ -576,11 +580,11 @@
       "owner_id": 8908513,
       "icon": "cypress.svg",
       "created_at": "2015-03-04T00:46:28.000Z",
-      "url": "https://www.cypress.io",
-      "slug": "cypress"
+      "url": "https://www.cypress.io"
     },
     {
       "name": "react-use",
+      "slug": "react-use",
       "full_name": "streamich/react-use",
       "description": "Collection of essential React Hooks",
       "stars": 9962,
@@ -589,11 +593,11 @@
       "tags": ["react"],
       "owner_id": 9773803,
       "created_at": "2018-10-27T10:16:05.000Z",
-      "url": "http://streamich.github.io/react-use",
-      "slug": "react-use"
+      "url": "http://streamich.github.io/react-use"
     },
     {
       "name": "Day.js",
+      "slug": "dayjs",
       "full_name": "iamkun/dayjs",
       "description": "Day.js 2KB immutable date library alternative to Moment.js with the same modern API",
       "stars": 25313,
@@ -601,11 +605,11 @@
       "monthly": [654, 413, 380, 486, 450, 459, 540, 476, 868, 1241, 651, 807],
       "tags": ["date"],
       "owner_id": 17680888,
-      "created_at": "2018-04-10T09:26:44.000Z",
-      "slug": "dayjs"
+      "created_at": "2018-04-10T09:26:44.000Z"
     },
     {
       "name": "json-server",
+      "slug": "json-server",
       "full_name": "typicode/json-server",
       "description": "Get a full fake REST API with zero coding in less than 30 seconds (seriously)",
       "stars": 44831,
@@ -613,11 +617,11 @@
       "monthly": [523, 529, 559, 592, 601, 670, 548, 634, 628, 675, 626, 806],
       "tags": ["test", "filesystem"],
       "owner_id": 5502029,
-      "created_at": "2013-11-27T13:21:13.000Z",
-      "slug": "json-server"
+      "created_at": "2013-11-27T13:21:13.000Z"
     },
     {
       "name": "Animate.css",
+      "slug": "animatecss",
       "full_name": "daneden/animate.css",
       "description": "A cross-browser library of CSS animations. As easy to use as an easy thing.",
       "stars": 64249,
@@ -626,11 +630,11 @@
       "tags": ["animation"],
       "owner_id": 439365,
       "created_at": "2011-10-12T10:07:38.000Z",
-      "url": "http://daneden.github.io/animate.css",
-      "slug": "animatecss"
+      "url": "http://daneden.github.io/animate.css"
     },
     {
       "name": "Vuetify",
+      "slug": "vuetify",
       "full_name": "vuetifyjs/vuetify",
       "description": "Material Component Framework for Vue",
       "stars": 23333,
@@ -640,11 +644,11 @@
       "owner_id": 22138497,
       "icon": "vuetify.svg",
       "created_at": "2016-09-12T00:39:35.000Z",
-      "url": "https://vuetifyjs.com",
-      "slug": "vuetify"
+      "url": "https://vuetifyjs.com"
     },
     {
       "name": "Nuxt",
+      "slug": "nuxt",
       "full_name": "nuxt/nuxt.js",
       "description": "The Vue.js Framework",
       "stars": 24805,
@@ -654,11 +658,11 @@
       "owner_id": 23360933,
       "icon": "nuxt.svg",
       "created_at": "2016-10-26T11:18:47.000Z",
-      "url": "https://nuxtjs.org",
-      "slug": "nuxt"
+      "url": "https://nuxtjs.org"
     },
     {
       "name": "33 JS Concepts",
+      "slug": "33-js-concepts",
       "full_name": "leonardomso/33-js-concepts",
       "description": "33 concepts every JavaScript developer should know.",
       "stars": 30727,
@@ -666,11 +670,11 @@
       "monthly": [210, 594, 640, 462, 296, 377, 320, 393, 479, 539, 921, 1879],
       "tags": ["learning"],
       "owner_id": 8030067,
-      "created_at": "2018-09-04T13:27:04.000Z",
-      "slug": "33-js-concepts"
+      "created_at": "2018-09-04T13:27:04.000Z"
     },
     {
       "name": "Echarts",
+      "slug": "echarts",
       "full_name": "apache/incubator-echarts",
       "description": "A powerful, interactive charting and visualization library for browser",
       "stars": 39012,
@@ -679,11 +683,11 @@
       "tags": ["chart"],
       "owner_id": 47359,
       "created_at": "2013-04-03T03:18:59.000Z",
-      "url": "http://echarts.apache.org/",
-      "slug": "echarts"
+      "url": "http://echarts.apache.org/"
     },
     {
       "name": "Pixi.js",
+      "slug": "pixijs",
       "full_name": "pixijs/pixi.js",
       "description": "The HTML5 Creation Engine: Create beautiful digital content with the fastest, most flexible 2D WebGL renderer.",
       "stars": 28271,
@@ -692,11 +696,11 @@
       "tags": ["game"],
       "owner_id": 5406849,
       "created_at": "2013-01-21T22:40:50.000Z",
-      "url": "http://pixijs.com",
-      "slug": "pixijs"
+      "url": "http://pixijs.com"
     },
     {
       "name": "TypeORM",
+      "slug": "typeorm",
       "full_name": "typeorm/typeorm",
       "description": "ORM for TypeScript and JavaScript (ES7, ES6, ES5). Supports MySQL, PostgreSQL, MariaDB, SQLite, MS SQL Server, Oracle, SAP Hana, WebSQL databases. Works in NodeJS, Browser, Ionic, Cordova and Electron platforms.",
       "stars": 17004,
@@ -705,11 +709,11 @@
       "tags": ["db"],
       "owner_id": 20165699,
       "created_at": "2016-02-29T07:41:14.000Z",
-      "url": "http://typeorm.io",
-      "slug": "typeorm"
+      "url": "http://typeorm.io"
     },
     {
       "name": "Jest",
+      "slug": "jest",
       "full_name": "facebook/jest",
       "description": "Delightful JavaScript Testing.",
       "stars": 29185,
@@ -719,11 +723,11 @@
       "owner_id": 69631,
       "icon": "jest.svg",
       "created_at": "2013-12-10T00:18:04.000Z",
-      "url": "https://jestjs.io",
-      "slug": "jest"
+      "url": "https://jestjs.io"
     },
     {
       "name": "React-spring",
+      "slug": "react-spring",
       "full_name": "react-spring/react-spring",
       "description": "A spring physics based React animation library",
       "stars": 15652,
@@ -732,11 +736,11 @@
       "tags": ["react", "animation"],
       "owner_id": 45790596,
       "created_at": "2018-03-07T15:39:32.000Z",
-      "url": "https://www.react-spring.io",
-      "slug": "react-spring"
+      "url": "https://www.react-spring.io"
     },
     {
       "name": "Webpack",
+      "slug": "webpack",
       "full_name": "webpack/webpack",
       "description": "A bundler for javascript and friends. Packs many modules into a few bundled assets. Code Splitting allows for loading parts of the application on demand. Through \"loaders\", modules can be CommonJs, AMD, ES6 modules, CSS, Images, JSON, Coffeescript, LESS, ... and your custom stuff.",
       "stars": 52594,
@@ -746,11 +750,11 @@
       "owner_id": 2105791,
       "icon": "webpack.svg",
       "created_at": "2012-03-10T10:08:14.000Z",
-      "url": "https://webpack.js.org",
-      "slug": "webpack"
+      "url": "https://webpack.js.org"
     },
     {
       "name": "Styled Components",
+      "slug": "styled-components",
       "full_name": "styled-components/styled-components",
       "description": "Visual primitives for the component age. Use the best bits of ES6 and CSS to style your apps without stress",
       "stars": 27412,
@@ -759,11 +763,11 @@
       "tags": ["css-in-js"],
       "owner_id": 20658825,
       "created_at": "2016-08-16T06:41:32.000Z",
-      "url": "https://styled-components.com",
-      "slug": "styled-components"
+      "url": "https://styled-components.com"
     },
     {
       "name": "Ink",
+      "slug": "ink",
       "full_name": "vadimdemedes/ink",
       "description": "React for interactive command-line apps",
       "stars": 12608,
@@ -771,11 +775,11 @@
       "monthly": [124, 152, 178, 183, 105, 171, 165, 487, 494, 1548, 759, 1489],
       "tags": ["react", "cli"],
       "owner_id": 697676,
-      "created_at": "2017-06-12T06:12:28.000Z",
-      "slug": "ink"
+      "created_at": "2017-06-12T06:12:28.000Z"
     },
     {
       "name": "vue-cli",
+      "slug": "vue-cli",
       "full_name": "vuejs/vue-cli",
       "description": "Standard Tooling for Vue.js Development",
       "stars": 24019,
@@ -784,11 +788,11 @@
       "tags": ["vue"],
       "owner_id": 6128107,
       "created_at": "2015-12-26T23:11:20.000Z",
-      "url": "https://cli.vuejs.org/",
-      "slug": "vue-cli"
+      "url": "https://cli.vuejs.org/"
     },
     {
       "name": "React Testing Library",
+      "slug": "react-testing-library",
       "full_name": "testing-library/react-testing-library",
       "description": "Simple and complete React DOM testing utilities that encourage good testing practices.",
       "stars": 10285,
@@ -797,11 +801,11 @@
       "tags": ["test", "react"],
       "owner_id": 49996085,
       "created_at": "2018-03-19T13:39:49.000Z",
-      "url": "https://testing-library.com/react",
-      "slug": "react-testing-library"
+      "url": "https://testing-library.com/react"
     },
     {
       "name": "react-beautiful-dnd",
+      "slug": "react-beautiful-dnd",
       "full_name": "atlassian/react-beautiful-dnd",
       "description": "Beautiful and accessible drag and drop for lists with React",
       "stars": 17601,
@@ -811,11 +815,11 @@
       "owner_id": 168166,
       "icon": "rbd.svg",
       "created_at": "2017-08-09T03:37:15.000Z",
-      "url": "https://react-beautiful-dnd.netlify.com",
-      "slug": "react-beautiful-dnd"
+      "url": "https://react-beautiful-dnd.netlify.com"
     },
     {
       "name": "Parcel",
+      "slug": "parcel",
       "full_name": "parcel-bundler/parcel",
       "description": "Blazing fast, zero configuration web application bundler",
       "stars": 34482,
@@ -825,11 +829,11 @@
       "owner_id": 32607881,
       "icon": "parcel.svg",
       "created_at": "2017-08-07T16:36:47.000Z",
-      "url": "https://parceljs.org",
-      "slug": "parcel"
+      "url": "https://parceljs.org"
     },
     {
       "name": "Docz",
+      "slug": "docz",
       "full_name": "doczjs/docz",
       "description": "It has never been so easy to document your things!",
       "stars": 17798,
@@ -837,13 +841,13 @@
       "monthly": [279, 324, 483, 318, 280, 399, 358, 460, 662, 599, 493, 473],
       "tags": ["react", "doc"],
       "owner_id": 39714731,
-      "icon": "docz.png",
+      "icon": "docz.svg",
       "created_at": "2018-03-17T04:24:10.000Z",
-      "url": "https://docz.site",
-      "slug": "docz"
+      "url": "https://docz.site"
     },
     {
       "name": "Vant",
+      "slug": "vant",
       "full_name": "youzan/vant",
       "description": "Lightweight Mobile UI Components built on Vue",
       "stars": 12378,
@@ -852,11 +856,11 @@
       "tags": ["vue", "component"],
       "owner_id": 11404085,
       "created_at": "2017-04-19T07:55:31.000Z",
-      "url": "https://youzan.github.io/vant",
-      "slug": "vant"
+      "url": "https://youzan.github.io/vant"
     },
     {
       "name": "Express",
+      "slug": "express",
       "full_name": "expressjs/express",
       "description": "Fast, unopinionated, minimalist web framework for node.",
       "stars": 46905,
@@ -866,11 +870,11 @@
       "owner_id": 5658226,
       "icon": "express.svg",
       "created_at": "2009-06-26T18:56:01.000Z",
-      "url": "https://expressjs.com",
-      "slug": "express"
+      "url": "https://expressjs.com"
     },
     {
       "name": "Quasar",
+      "slug": "quasar",
       "full_name": "quasarframework/quasar",
       "description": "Responsive Single Page Apps, Server-side Render Apps, Progressive Web Apps, Hybrid Mobile Apps (that look native!) & Electron Apps, all using the same codebase.",
       "stars": 13296,
@@ -880,10 +884,11 @@
       "owner_id": 23064371,
       "created_at": "2015-10-05T15:45:36.000Z",
       "url": "https://quasar.dev",
-      "slug": "quasar"
+      "icon": "quasar.svg"
     },
     {
       "name": "ngx-admin",
+      "slug": "ngx-admin",
       "full_name": "akveo/ngx-admin",
       "description": "Customizable admin dashboard template based on Angular 8+",
       "stars": 19473,
@@ -892,11 +897,11 @@
       "tags": ["angular", "dashboard"],
       "owner_id": 11921694,
       "created_at": "2016-05-25T10:09:03.000Z",
-      "url": "https://akveo.github.io/ngx-admin/",
-      "slug": "ngx-admin"
+      "url": "https://akveo.github.io/ngx-admin/"
     },
     {
       "name": "Papers we love",
+      "slug": "papers-we-love",
       "full_name": "papers-we-love/papers-we-love",
       "description": "Papers from the computer science community to read and discuss.",
       "stars": 37616,
@@ -905,11 +910,11 @@
       "tags": ["learning"],
       "owner_id": 6187757,
       "created_at": "2013-12-15T14:31:41.000Z",
-      "url": "http://paperswelove.org/",
-      "slug": "papers-we-love"
+      "url": "http://paperswelove.org/"
     },
     {
       "name": "Front-end Job Interview Questions",
+      "slug": "front-end-job-interview-questions",
       "full_name": "h5bp/Front-end-Developer-Interview-Questions",
       "description": "A list of helpful front-end related questions you can use to interview potential candidates, test yourself or completely ignore.",
       "stars": 43301,
@@ -918,11 +923,11 @@
       "tags": ["learning"],
       "owner_id": 1136800,
       "created_at": "2012-02-09T23:34:10.000Z",
-      "url": "https://h5bp.org/Front-end-Developer-Interview-Questions/",
-      "slug": "front-end-job-interview-questions"
+      "url": "https://h5bp.org/Front-end-Developer-Interview-Questions/"
     },
     {
       "name": "Docusaurus",
+      "slug": "docusaurus",
       "full_name": "facebook/docusaurus",
       "description": "Easy to maintain open source documentation websites.",
       "stars": 15080,
@@ -932,11 +937,11 @@
       "owner_id": 69631,
       "icon": "docusaurus.svg",
       "created_at": "2017-06-20T16:13:53.000Z",
-      "url": "https://docusaurus.io",
-      "slug": "docusaurus"
+      "url": "https://docusaurus.io"
     },
     {
       "name": "React Router",
+      "slug": "react-router",
       "full_name": "ReactTraining/react-router",
       "description": "Declarative routing for React",
       "stars": 38831,
@@ -946,11 +951,11 @@
       "owner_id": 11823761,
       "icon": "react-router.svg",
       "created_at": "2014-05-16T22:22:51.000Z",
-      "url": "https://reacttraining.com/react-router/",
-      "slug": "react-router"
+      "url": "https://reacttraining.com/react-router/"
     },
     {
       "name": "VuePress",
+      "slug": "vuepress",
       "full_name": "vuejs/vuepress",
       "description": "Minimalistic Vue-powered static site generator",
       "stars": 15238,
@@ -959,11 +964,11 @@
       "tags": ["vue", "ssg"],
       "owner_id": 6128107,
       "created_at": "2018-04-05T16:58:38.000Z",
-      "url": "https://vuepress.vuejs.org",
-      "slug": "vuepress"
+      "url": "https://vuepress.vuejs.org"
     },
     {
       "name": "Prisma",
+      "slug": "prisma",
       "full_name": "prisma/prisma",
       "description": "Database Tools incl. ORM, Migrations and Admin UI (Postgres, MySQL & MongoDB)",
       "stars": 16536,
@@ -973,11 +978,11 @@
       "owner_id": 17219288,
       "icon": "prisma.svg",
       "created_at": "2016-09-25T12:54:40.000Z",
-      "url": "https://www.prisma.io",
-      "slug": "prisma"
+      "url": "https://www.prisma.io"
     },
     {
       "name": "react-admin",
+      "slug": "react-admin",
       "full_name": "marmelab/react-admin",
       "description": "A frontend Framework for building B2B applications running in the browser on top of REST/GraphQL APIs, using ES6, React and Material Design",
       "stars": 10902,
@@ -986,11 +991,11 @@
       "tags": ["dashboard", "react", "redux", "material"],
       "owner_id": 3116319,
       "created_at": "2016-07-13T07:58:54.000Z",
-      "url": "http://marmelab.com/react-admin",
-      "slug": "react-admin"
+      "url": "http://marmelab.com/react-admin"
     },
     {
       "name": "React Window",
+      "slug": "react-window",
       "full_name": "bvaughn/react-window",
       "description": "React components for efficiently rendering large lists and tabular data",
       "stars": 6977,
@@ -999,11 +1004,11 @@
       "tags": ["react", "scrolling"],
       "owner_id": 29597,
       "created_at": "2018-05-07T14:45:51.000Z",
-      "url": "https://react-window.now.sh/",
-      "slug": "react-window"
+      "url": "https://react-window.now.sh/"
     },
     {
       "name": "Babel",
+      "slug": "babel",
       "full_name": "babel/babel",
       "description": "A compiler for writing next generation JavaScript.",
       "stars": 35533,
@@ -1013,11 +1018,11 @@
       "owner_id": 9637642,
       "icon": "babel.svg",
       "created_at": "2014-09-28T13:38:23.000Z",
-      "url": "https://babeljs.io/",
-      "slug": "babel"
+      "url": "https://babeljs.io/"
     },
     {
       "name": "Vuex",
+      "slug": "vuex",
       "full_name": "vuejs/vuex",
       "description": "Centralized State Management for Vue.js.",
       "stars": 22576,
@@ -1026,8 +1031,7 @@
       "tags": ["flux", "vue", "state"],
       "owner_id": 6128107,
       "created_at": "2015-07-16T04:21:26.000Z",
-      "url": "https://vuex.vuejs.org",
-      "slug": "vuex"
+      "url": "https://vuex.vuejs.org"
     },
     {
       "name": "React Table",
@@ -1043,6 +1047,7 @@
     },
     {
       "name": "React Native for Web",
+      "slug": "react-native-for-web",
       "full_name": "necolas/react-native-web",
       "description": "React Native for Web",
       "stars": 15581,
@@ -1051,11 +1056,11 @@
       "tags": ["react-native", "component"],
       "owner_id": 239676,
       "created_at": "2015-06-09T19:25:38.000Z",
-      "url": "https://necolas.github.io/react-native-web/docs",
-      "slug": "react-native-for-web"
+      "url": "https://necolas.github.io/react-native-web/docs"
     },
     {
       "name": "Fastify",
+      "slug": "fastify",
       "full_name": "fastify/fastify",
       "description": "Fast and low overhead web framework, for Node.js",
       "stars": 13189,
@@ -1065,11 +1070,11 @@
       "owner_id": 24939410,
       "icon": "fastify.svg",
       "created_at": "2016-09-28T19:10:14.000Z",
-      "url": "https://www.fastify.io",
-      "slug": "fastify"
+      "url": "https://www.fastify.io"
     },
     {
       "name": "Omi",
+      "slug": "omi",
       "full_name": "Tencent/omi",
       "description": "Next Front End Framework",
       "stars": 10633,
@@ -1079,11 +1084,11 @@
       "owner_id": 18461506,
       "icon": "omi.svg",
       "created_at": "2015-05-31T14:24:58.000Z",
-      "url": "http://omijs.org",
-      "slug": "omi"
+      "url": "http://omijs.org"
     },
     {
       "name": "Preact",
+      "slug": "preact",
       "full_name": "preactjs/preact",
       "description": "Fast 3kB React alternative with the same modern API. Components & Virtual DOM.",
       "stars": 25145,
@@ -1093,11 +1098,11 @@
       "owner_id": 26872990,
       "icon": "preact.svg",
       "created_at": "2015-09-11T02:40:18.000Z",
-      "url": "https://preactjs.com",
-      "slug": "preact"
+      "url": "https://preactjs.com"
     },
     {
       "name": "iView",
+      "slug": "iview",
       "full_name": "iview/iview",
       "description": "A high quality UI Toolkit built on Vue.js 2.0",
       "stars": 22955,
@@ -1107,11 +1112,11 @@
       "owner_id": 20693613,
       "icon": "iview.svg",
       "created_at": "2016-07-28T01:52:59.000Z",
-      "url": "http://iview.talkingdata.com",
-      "slug": "iview"
+      "url": "http://iview.talkingdata.com"
     },
     {
       "name": "Gridsome",
+      "slug": "gridsome",
       "full_name": "gridsome/gridsome",
       "description": "️Build modern JAMstack websites with Vue.js",
       "stars": 5248,
@@ -1120,11 +1125,11 @@
       "tags": ["ssg", "vue", "graphql"],
       "owner_id": 17981963,
       "created_at": "2018-07-31T22:55:06.000Z",
-      "url": "https://gridsome.org",
-      "slug": "gridsome"
+      "url": "https://gridsome.org"
     },
     {
       "name": "Koa",
+      "slug": "koa",
       "full_name": "koajs/koa",
       "description": "Expressive middleware for node.js using ES2017 async functions",
       "stars": 28296,
@@ -1133,11 +1138,11 @@
       "tags": ["nodejs-framework"],
       "owner_id": 5055057,
       "created_at": "2013-07-20T18:53:45.000Z",
-      "url": "https://koajs.com",
-      "slug": "koa"
+      "url": "https://koajs.com"
     },
     {
       "name": "Filepond",
+      "slug": "filepond",
       "full_name": "pqina/filepond",
       "description": "A flexible and fun JavaScript file upload library",
       "stars": 8494,
@@ -1146,11 +1151,11 @@
       "tags": ["upload", "react", "vue"],
       "owner_id": 22966117,
       "created_at": "2017-10-09T12:17:44.000Z",
-      "url": "https://pqina.nl/filepond",
-      "slug": "filepond"
+      "url": "https://pqina.nl/filepond"
     },
     {
       "name": "Ionic",
+      "slug": "ionic",
       "full_name": "ionic-team/ionic",
       "description": "Build amazing Native and Progressive Web Apps with web technologies. One app running on everything",
       "stars": 40003,
@@ -1160,11 +1165,11 @@
       "owner_id": 3171503,
       "icon": "ionic.svg",
       "created_at": "2013-08-20T23:06:02.000Z",
-      "url": "https://ionicframework.com/",
-      "slug": "ionic"
+      "url": "https://ionicframework.com/"
     },
     {
       "name": "umi",
+      "slug": "umi",
       "full_name": "umijs/umi",
       "description": "Pluggable enterprise-level react application framework.",
       "stars": 6943,
@@ -1173,11 +1178,11 @@
       "tags": ["nodejs-framework", "react"],
       "owner_id": 33895495,
       "created_at": "2017-11-22T10:09:36.000Z",
-      "url": "https://umijs.org/",
-      "slug": "umi"
+      "url": "https://umijs.org/"
     },
     {
       "name": "Expo",
+      "slug": "expo",
       "full_name": "expo/expo",
       "description": "An open-source platform for making universal native apps with React. Expo runs on Android, iOS, and the web.",
       "stars": 8456,
@@ -1187,10 +1192,11 @@
       "owner_id": 12504344,
       "created_at": "2016-08-15T17:14:25.000Z",
       "url": "https://docs.expo.io/",
-      "slug": "expo"
+      "icon": "expo.svg"
     },
     {
       "name": "Egg",
+      "slug": "egg",
       "full_name": "eggjs/egg",
       "description": "Born to build better enterprise frameworks and apps with Node.js & Koa",
       "stars": 14713,
@@ -1199,11 +1205,11 @@
       "tags": ["nodejs-framework"],
       "owner_id": 15833670,
       "created_at": "2016-06-18T06:53:23.000Z",
-      "url": "https://eggjs.org",
-      "slug": "egg"
+      "url": "https://eggjs.org"
     },
     {
       "name": "Apollo client",
+      "slug": "apollo-client",
       "full_name": "apollographql/apollo-client",
       "description": "A fully-featured, production ready caching GraphQL client for every UI framework and GraphQL server",
       "stars": 12999,
@@ -1213,11 +1219,11 @@
       "owner_id": 17189275,
       "icon": "apollo.svg",
       "created_at": "2016-02-26T20:25:00.000Z",
-      "url": "https://apollographql.com/client",
-      "slug": "apollo-client"
+      "url": "https://apollographql.com/client"
     },
     {
       "name": "Emotion",
+      "slug": "emotion",
       "full_name": "emotion-js/emotion",
       "description": "CSS-in-JS library designed for high performance style composition",
       "stars": 9823,
@@ -1226,11 +1232,11 @@
       "tags": ["css-in-js"],
       "owner_id": 31557565,
       "created_at": "2017-05-27T04:23:45.000Z",
-      "url": "https://emotion.sh/",
-      "slug": "emotion"
+      "url": "https://emotion.sh/"
     },
     {
       "name": "Apollo Server",
+      "slug": "apollo-server",
       "full_name": "apollographql/apollo-server",
       "description": "GraphQL server for Express, Connect, Hapi, Koa and more",
       "stars": 8828,
@@ -1240,11 +1246,11 @@
       "owner_id": 17189275,
       "icon": "apollo.svg",
       "created_at": "2016-04-21T09:26:01.000Z",
-      "url": "https://www.apollographql.com/docs/apollo-server/",
-      "slug": "apollo-server"
+      "url": "https://www.apollographql.com/docs/apollo-server/"
     },
     {
       "name": "Linaria",
+      "slug": "linaria",
       "full_name": "callstack/linaria",
       "description": "Zero-runtime CSS in JS library",
       "stars": 4750,
@@ -1254,10 +1260,11 @@
       "owner_id": 42239399,
       "created_at": "2017-05-23T00:52:34.000Z",
       "url": "https://linaria.now.sh",
-      "slug": "linaria"
+      "icon": "linaria.svg"
     },
     {
       "name": "Rollup",
+      "slug": "rollup",
       "full_name": "rollup/rollup",
       "description": "Next-generation ES module bundler",
       "stars": 17318,
@@ -1267,11 +1274,11 @@
       "owner_id": 12554859,
       "icon": "rollup.svg",
       "created_at": "2015-05-14T22:26:28.000Z",
-      "url": "https://rollupjs.org",
-      "slug": "rollup"
+      "url": "https://rollupjs.org"
     },
     {
       "name": "cube-ui",
+      "slug": "cube-ui",
       "full_name": "didi/cube-ui",
       "description": "A fantastic mobile ui lib implement by Vue",
       "stars": 7660,
@@ -1280,11 +1287,11 @@
       "tags": ["vue", "mobile"],
       "owner_id": 27521938,
       "created_at": "2017-11-03T06:17:27.000Z",
-      "url": "https://didi.github.io/cube-ui/",
-      "slug": "cube-ui"
+      "url": "https://didi.github.io/cube-ui/"
     },
     {
       "name": "Stencil",
+      "slug": "stencil",
       "full_name": "ionic-team/stencil",
       "description": "A Web Component compiler for building fast, reusable UI components and Progressive Web Apps  Built by the Ionic Framework team",
       "stars": 7183,
@@ -1294,11 +1301,11 @@
       "owner_id": 3171503,
       "icon": "stencil.svg",
       "created_at": "2017-02-15T18:57:07.000Z",
-      "url": "https://stenciljs.com/",
-      "slug": "stencil"
+      "url": "https://stenciljs.com/"
     },
     {
       "name": "GraphiQL",
+      "slug": "graphiql",
       "full_name": "graphql/graphiql",
       "description": "GraphiQL & the GraphQL LSP Reference Ecosystem for building browser & IDE tools.",
       "stars": 9852,
@@ -1306,11 +1313,11 @@
       "monthly": [170, 184, 160, 172, 224, 197, 177, 203, 241, 227, 177, 234],
       "tags": ["graphql"],
       "owner_id": 12972006,
-      "created_at": "2015-08-11T02:56:22.000Z",
-      "slug": "graphiql"
+      "created_at": "2015-08-11T02:56:22.000Z"
     },
     {
       "name": "styled-system",
+      "slug": "styled-system",
       "full_name": "styled-system/styled-system",
       "description": "⬢ Style props for rapid UI development",
       "stars": 5305,
@@ -1319,11 +1326,11 @@
       "tags": ["css-in-js"],
       "owner_id": 47362392,
       "created_at": "2017-06-14T23:21:17.000Z",
-      "url": "https://styled-system.com",
-      "slug": "styled-system"
+      "url": "https://styled-system.com"
     },
     {
       "name": "Material Design for Angular",
+      "slug": "material-design-for-angular",
       "full_name": "angular/components",
       "description": "Component infrastructure and Material Design components for Angular",
       "stars": 19253,
@@ -1332,11 +1339,11 @@
       "tags": ["material", "angular", "component"],
       "owner_id": 139426,
       "created_at": "2016-01-04T18:50:02.000Z",
-      "url": "https://material.angular.io",
-      "slug": "material-design-for-angular"
+      "url": "https://material.angular.io"
     },
     {
       "name": "dva",
+      "slug": "dva",
       "full_name": "dvajs/dva",
       "description": "React and redux based, lightweight and elm-style framework. (Inspired by elm and choo)",
       "stars": 14337,
@@ -1345,11 +1352,11 @@
       "tags": ["framework", "redux"],
       "owner_id": 20552239,
       "created_at": "2016-06-24T09:06:16.000Z",
-      "url": "https://dvajs.com/",
-      "slug": "dva"
+      "url": "https://dvajs.com/"
     },
     {
       "name": "NativeBase",
+      "slug": "nativebase",
       "full_name": "GeekyAnts/NativeBase",
       "description": "Essential cross-platform UI components for React Native",
       "stars": 13233,
@@ -1359,7 +1366,7 @@
       "owner_id": 18482943,
       "created_at": "2016-04-15T11:37:23.000Z",
       "url": "https://nativebase.io/",
-      "slug": "nativebase"
+      "icon": "nativebase.svg"
     },
     {
       "name": "Puppeteer Recorder",
@@ -1375,6 +1382,7 @@
     },
     {
       "name": "Enzyme",
+      "slug": "enzyme",
       "full_name": "airbnb/enzyme",
       "description": "JavaScript Testing utilities for React",
       "stars": 18348,
@@ -1383,11 +1391,11 @@
       "tags": ["test", "react"],
       "owner_id": 698437,
       "created_at": "2015-11-10T21:45:38.000Z",
-      "url": "https://airbnb.io/enzyme/",
-      "slug": "enzyme"
+      "url": "https://airbnb.io/enzyme/"
     },
     {
       "name": "NativeScript",
+      "slug": "nativescript",
       "full_name": "NativeScript/NativeScript",
       "description": "NativeScript is an open source framework for building truly native mobile apps with JavaScript. Use web skills, like Angular and Vue.js, FlexBox and CSS, and get native UI and performance on iOS and Android.",
       "stars": 18054,
@@ -1397,11 +1405,11 @@
       "owner_id": 7392261,
       "icon": "nativescript.svg",
       "created_at": "2015-03-01T09:47:08.000Z",
-      "url": "https://www.nativescript.org",
-      "slug": "nativescript"
+      "url": "https://www.nativescript.org"
     },
     {
       "name": "URQL",
+      "slug": "urql",
       "full_name": "FormidableLabs/urql",
       "description": "A highly customizable and versatile GraphQL client for React",
       "stars": 4016,
@@ -1410,11 +1418,11 @@
       "tags": ["graphql", "react"],
       "owner_id": 5078602,
       "created_at": "2018-01-24T01:44:42.000Z",
-      "url": "https://formidable.com/open-source/urql",
-      "slug": "urql"
+      "url": "https://formidable.com/open-source/urql"
     },
     {
       "name": "Mint UI",
+      "slug": "mint-ui",
       "full_name": "ElemeFE/mint-ui",
       "description": "Mobile UI elements for Vue.js",
       "stars": 15405,
@@ -1424,11 +1432,11 @@
       "owner_id": 12810740,
       "icon": "mint-ui.svg",
       "created_at": "2016-05-17T09:54:10.000Z",
-      "url": "http://mint-ui.github.io/#!/en",
-      "slug": "mint-ui"
+      "url": "http://mint-ui.github.io/#!/en"
     },
     {
       "name": "Angular CLI",
+      "slug": "angular-cli",
       "full_name": "angular/angular-cli",
       "description": "CLI tool for Angular",
       "stars": 22867,
@@ -1437,11 +1445,11 @@
       "tags": ["angular", "scaffolding"],
       "owner_id": 139426,
       "created_at": "2015-06-04T19:49:37.000Z",
-      "url": "https://cli.angular.io/",
-      "slug": "angular-cli"
+      "url": "https://cli.angular.io/"
     },
     {
       "name": "Adonis",
+      "slug": "adonis",
       "full_name": "adonisjs/adonis-framework",
       "description": "The Node.js Framework highly focused on developer ergonomics, stability and confidence",
       "stars": 7531,
@@ -1450,11 +1458,11 @@
       "tags": ["nodejs-framework"],
       "owner_id": 13810373,
       "created_at": "2015-08-15T17:03:54.000Z",
-      "url": "https://adonisjs.com",
-      "slug": "adonis"
+      "url": "https://adonisjs.com"
     },
     {
       "name": "Relay",
+      "slug": "relay",
       "full_name": "facebook/relay",
       "description": "Relay is a JavaScript framework for building data-driven React applications.",
       "stars": 14010,
@@ -1464,11 +1472,11 @@
       "owner_id": 69631,
       "icon": "relay.svg",
       "created_at": "2015-08-10T22:09:16.000Z",
-      "url": "https://relay.dev",
-      "slug": "relay"
+      "url": "https://relay.dev"
     },
     {
       "name": "jsdom",
+      "slug": "jsdom",
       "full_name": "jsdom/jsdom",
       "description": "A JavaScript implementation of various web standards, for use with Node.js",
       "stars": 13429,
@@ -1477,11 +1485,11 @@
       "tags": ["test"],
       "owner_id": 9271229,
       "icon": "jsdom.svg",
-      "created_at": "2010-01-19T06:55:19.000Z",
-      "slug": "jsdom"
+      "created_at": "2010-01-19T06:55:19.000Z"
     },
     {
       "name": "GraphQL Playground",
+      "slug": "graphql-playground",
       "full_name": "prisma-labs/graphql-playground",
       "description": "GraphQL IDE for better development workflows (GraphQL Subscriptions, interactive docs & collaboration)",
       "stars": 5557,
@@ -1489,11 +1497,11 @@
       "monthly": [107, 133, 102, 145, 154, 166, 175, 191, 195, 191, 175, 220],
       "tags": ["graphql"],
       "owner_id": 55085183,
-      "created_at": "2017-01-25T13:19:29.000Z",
-      "slug": "graphql-playground"
+      "created_at": "2017-01-25T13:19:29.000Z"
     },
     {
       "name": "Mocha",
+      "slug": "mocha",
       "full_name": "mochajs/mocha",
       "description": "️ simple, flexible, fun javascript test framework for node.js & the browser",
       "stars": 18864,
@@ -1503,11 +1511,11 @@
       "owner_id": 8770005,
       "icon": "mocha.svg",
       "created_at": "2011-03-07T18:44:25.000Z",
-      "url": "https://mochajs.org",
-      "slug": "mocha"
+      "url": "https://mochajs.org"
     },
     {
       "name": "AVA",
+      "slug": "ava",
       "full_name": "avajs/ava",
       "description": "JavaScript test runner",
       "stars": 17361,
@@ -1516,11 +1524,11 @@
       "tags": ["test-framework", "test"],
       "owner_id": 8527916,
       "icon": "ava.svg",
-      "created_at": "2014-11-18T17:20:26.000Z",
-      "slug": "ava"
+      "created_at": "2014-11-18T17:20:26.000Z"
     },
     {
       "name": "CSS Modules",
+      "slug": "css-modules",
       "full_name": "css-modules/css-modules",
       "description": "Documentation about css-modules",
       "stars": 13022,
@@ -1528,11 +1536,11 @@
       "monthly": [107, 110, 120, 141, 141, 129, 126, 180, 167, 186, 174, 185],
       "tags": ["css-in-js"],
       "owner_id": 12612655,
-      "created_at": "2015-05-25T21:54:47.000Z",
-      "slug": "css-modules"
+      "created_at": "2015-05-25T21:54:47.000Z"
     },
     {
       "name": "Weex",
+      "slug": "weex",
       "full_name": "apache/incubator-weex",
       "description": "A framework for building Mobile cross-platform UI.",
       "stars": 13280,
@@ -1542,11 +1550,11 @@
       "owner_id": 47359,
       "icon": "weex.svg",
       "created_at": "2017-01-06T08:00:06.000Z",
-      "url": "https://weex.apache.org",
-      "slug": "weex"
+      "url": "https://weex.apache.org"
     },
     {
       "name": "Feathers",
+      "slug": "feathers",
       "full_name": "feathersjs/feathers",
       "description": "A framework for real-time applications and REST APIs with JavaScript and TypeScript",
       "stars": 12035,
@@ -1556,11 +1564,11 @@
       "owner_id": 5321853,
       "icon": "feathers.svg",
       "created_at": "2011-10-19T22:45:16.000Z",
-      "url": "https://feathersjs.com",
-      "slug": "feathers"
+      "url": "https://feathersjs.com"
     },
     {
       "name": "NG-ZORRO",
+      "slug": "ng-zorro",
       "full_name": "NG-ZORRO/ng-zorro-antd",
       "description": "An enterprise-class UI components based on Ant Design and Angular.",
       "stars": 5988,
@@ -1569,11 +1577,11 @@
       "tags": ["angular", "component"],
       "owner_id": 30223759,
       "created_at": "2017-08-08T14:59:33.000Z",
-      "url": "https://ng.ant.design",
-      "slug": "ng-zorro"
+      "url": "https://ng.ant.design"
     },
     {
       "name": "Flow",
+      "slug": "flow",
       "full_name": "facebook/flow",
       "description": "Adds static typing to JavaScript to improve developer productivity and code quality.",
       "stars": 20323,
@@ -1583,11 +1591,11 @@
       "owner_id": 69631,
       "icon": "flow.svg",
       "created_at": "2014-10-28T17:17:45.000Z",
-      "url": "https://flow.org/",
-      "slug": "flow"
+      "url": "https://flow.org/"
     },
     {
       "name": "Gun",
+      "slug": "gun",
       "full_name": "amark/gun",
       "description": "A realtime, decentralized, offline-first, graph protocol to sync the web.",
       "stars": 11028,
@@ -1597,11 +1605,11 @@
       "owner_id": 433412,
       "icon": "gun.svg",
       "created_at": "2014-07-31T15:52:10.000Z",
-      "url": "https://gun.eco/docs",
-      "slug": "gun"
+      "url": "https://gun.eco/docs"
     },
     {
       "name": "Mithril",
+      "slug": "mithril",
       "full_name": "MithrilJS/mithril.js",
       "description": "A JavaScript Framework for Building Brilliant Applications",
       "stars": 11971,
@@ -1611,11 +1619,11 @@
       "owner_id": 19475707,
       "icon": "mithril.svg",
       "created_at": "2014-03-17T01:59:39.000Z",
-      "url": "https://mithril.js.org",
-      "slug": "mithril"
+      "url": "https://mithril.js.org"
     },
     {
       "name": "Vue Native",
+      "slug": "vue-native",
       "full_name": "GeekyAnts/vue-native-core",
       "description": "Vue Native is a framework to build cross platform native mobile apps using JavaScript",
       "stars": 6827,
@@ -1624,11 +1632,11 @@
       "tags": ["mobile", "vue"],
       "owner_id": 18482943,
       "created_at": "2018-02-23T11:44:30.000Z",
-      "url": "https://vue-native.io",
-      "slug": "vue-native"
+      "url": "https://vue-native.io"
     },
     {
       "name": "Marko",
+      "slug": "marko",
       "full_name": "marko-js/marko",
       "description": "A declarative, HTML-based language that makes building web apps fun",
       "stars": 9364,
@@ -1638,11 +1646,11 @@
       "owner_id": 11873696,
       "icon": "marko.svg",
       "created_at": "2014-01-07T23:58:21.000Z",
-      "url": "https://markojs.com/",
-      "slug": "marko"
+      "url": "https://markojs.com/"
     },
     {
       "name": "Reason",
+      "slug": "reason",
       "full_name": "facebook/reason",
       "description": "Simple, fast & type safe code that leverages the JavaScript & OCaml ecosystems",
       "stars": 8412,
@@ -1652,11 +1660,11 @@
       "owner_id": 69631,
       "icon": "reason.svg",
       "created_at": "2015-11-16T08:22:32.000Z",
-      "url": "http://reasonml.github.io",
-      "slug": "reason"
+      "url": "http://reasonml.github.io"
     },
     {
       "name": "Hapi",
+      "slug": "hapi",
       "full_name": "hapijs/hapi",
       "description": "The Simple, Secure Framework Developers Trust",
       "stars": 11959,
@@ -1666,11 +1674,11 @@
       "owner_id": 3774533,
       "icon": "hapi.svg",
       "created_at": "2011-08-06T00:35:39.000Z",
-      "url": "https://hapi.dev",
-      "slug": "hapi"
+      "url": "https://hapi.dev"
     },
     {
       "name": "NgRx",
+      "slug": "ngrx",
       "full_name": "ngrx/platform",
       "description": "Reactive libraries for Angular",
       "stars": 5533,
@@ -1679,11 +1687,11 @@
       "tags": ["angular", "reactive", "state"],
       "owner_id": 16272733,
       "created_at": "2017-03-02T19:34:15.000Z",
-      "url": "https://ngrx.io",
-      "slug": "ngrx"
+      "url": "https://ngrx.io"
     },
     {
       "name": "Microbundle",
+      "slug": "microbundle",
       "full_name": "developit/microbundle",
       "description": "Zero-configuration bundler for tiny modules.",
       "stars": 4222,
@@ -1691,11 +1699,11 @@
       "monthly": [74, 59, 87, 66, 82, 74, 119, 94, 104, 238, 101, 151],
       "tags": ["module", "build"],
       "owner_id": 105127,
-      "created_at": "2017-12-11T21:51:02.000Z",
-      "slug": "microbundle"
+      "created_at": "2017-12-11T21:51:02.000Z"
     },
     {
       "name": "RE:DOM",
+      "slug": "re:dom",
       "full_name": "redom/redom",
       "description": "Tiny (2 KB) turboboosted JavaScript library for creating user interfaces.",
       "stars": 2830,
@@ -1704,11 +1712,11 @@
       "tags": ["framework"],
       "owner_id": 21295422,
       "created_at": "2016-08-28T17:32:43.000Z",
-      "url": "https://redom.js.org",
-      "slug": "re:dom"
+      "url": "https://redom.js.org"
     },
     {
       "name": "ag-grid",
+      "slug": "ag-grid",
       "full_name": "ag-grid/ag-grid",
       "description": "Advanced Data Grid / Data Table supporting Javascript / React / AngularJS / Web Components",
       "stars": 5905,
@@ -1717,11 +1725,11 @@
       "tags": ["table", "react", "angular"],
       "owner_id": 30720768,
       "created_at": "2014-12-23T16:20:14.000Z",
-      "url": "http://www.ag-grid.com",
-      "slug": "ag-grid"
+      "url": "http://www.ag-grid.com"
     },
     {
       "name": "Moleculer",
+      "slug": "moleculer",
       "full_name": "moleculerjs/moleculer",
       "description": "Progressive microservices framework for Node.js",
       "stars": 3185,
@@ -1730,11 +1738,11 @@
       "tags": ["microservice", "nodejs-framework"],
       "owner_id": 25477106,
       "created_at": "2017-02-17T11:11:35.000Z",
-      "url": "https://moleculer.services/",
-      "slug": "moleculer"
+      "url": "https://moleculer.services/"
     },
     {
       "name": "Polished",
+      "slug": "polished",
       "full_name": "styled-components/polished",
       "description": "A lightweight toolset for writing styles in JavaScript",
       "stars": 5696,
@@ -1743,11 +1751,11 @@
       "tags": ["css-in-js"],
       "owner_id": 20658825,
       "created_at": "2016-11-03T14:39:21.000Z",
-      "url": "https://polished.js.org/",
-      "slug": "polished"
+      "url": "https://polished.js.org/"
     },
     {
       "name": "Stimulus",
+      "slug": "stimulus",
       "full_name": "stimulusjs/stimulus",
       "description": "A modest JavaScript framework for the HTML you already have",
       "stars": 7827,
@@ -1757,10 +1765,11 @@
       "owner_id": 32970053,
       "created_at": "2016-12-17T00:19:29.000Z",
       "url": "https://stimulusjs.org/",
-      "slug": "stimulus"
+      "icon": "stimulus.svg"
     },
     {
       "name": "Micro",
+      "slug": "micro",
       "full_name": "zeit/micro",
       "description": "Asynchronous HTTP microservices",
       "stars": 8997,
@@ -1768,11 +1777,11 @@
       "monthly": [56, 80, 60, 79, 100, 90, 65, 112, 101, 102, 125, 123],
       "tags": ["microservice", "nodejs-framework"],
       "owner_id": 14985020,
-      "created_at": "2016-01-23T05:17:00.000Z",
-      "slug": "micro"
+      "created_at": "2016-01-23T05:17:00.000Z"
     },
     {
       "name": "Hyperapp",
+      "slug": "hyperapp",
       "full_name": "jorgebucaran/hyperapp",
       "description": "The tiny framework for building web interfaces.",
       "stars": 17102,
@@ -1782,11 +1791,11 @@
       "owner_id": 56996,
       "icon": "hyperapp.svg",
       "created_at": "2017-01-20T05:20:21.000Z",
-      "url": "https://hyperapp.dev",
-      "slug": "hyperapp"
+      "url": "https://hyperapp.dev"
     },
     {
       "name": "Styled JSX",
+      "slug": "styled-jsx",
       "full_name": "zeit/styled-jsx",
       "description": "Full CSS support for JSX without compromises",
       "stars": 5105,
@@ -1794,11 +1803,11 @@
       "monthly": [84, 113, 77, 91, 76, 85, 67, 103, 97, 110, 87, 117],
       "tags": ["css-in-js"],
       "owner_id": 14985020,
-      "created_at": "2016-12-05T13:58:02.000Z",
-      "slug": "styled-jsx"
+      "created_at": "2016-12-05T13:58:02.000Z"
     },
     {
       "name": "Sucrase",
+      "slug": "sucrase",
       "full_name": "alangpierce/sucrase",
       "description": "Super-fast alternative to Babel for when you can target modern JS runtimes",
       "stars": 2187,
@@ -1807,11 +1816,11 @@
       "tags": ["compiler", "code-parser"],
       "owner_id": 211605,
       "created_at": "2017-10-03T16:54:00.000Z",
-      "url": "https://sucrase.io",
-      "slug": "sucrase"
+      "url": "https://sucrase.io"
     },
     {
       "name": "AMP",
+      "slug": "amp",
       "full_name": "ampproject/amphtml",
       "description": "The AMP web component framework.",
       "stars": 13381,
@@ -1821,11 +1830,11 @@
       "owner_id": 14114390,
       "icon": "amp.svg",
       "created_at": "2015-09-01T22:10:53.000Z",
-      "url": "https://amp.dev",
-      "slug": "amp"
+      "url": "https://amp.dev"
     },
     {
       "name": "Clarity Design System",
+      "slug": "clarity-design-system",
       "full_name": "vmware/clarity",
       "description": "UX guidelines, HTML/CSS framework, and Angular components working together to craft exceptional experiences",
       "stars": 5492,
@@ -1834,11 +1843,11 @@
       "tags": ["angular", "component"],
       "owner_id": 473334,
       "created_at": "2016-09-29T17:24:17.000Z",
-      "url": "http://clarity.design",
-      "slug": "clarity-design-system"
+      "url": "http://clarity.design"
     },
     {
       "name": "Sails",
+      "slug": "sails",
       "full_name": "balderdashy/sails",
       "description": "Realtime MVC Framework for Node.js",
       "stars": 21108,
@@ -1848,11 +1857,11 @@
       "owner_id": 1445252,
       "icon": "sails.svg",
       "created_at": "2012-03-18T19:46:15.000Z",
-      "url": "https://sailsjs.com",
-      "slug": "sails"
+      "url": "https://sailsjs.com"
     },
     {
       "name": "Rax",
+      "slug": "rax",
       "full_name": "alibaba/rax",
       "description": "The fastest way to build universal application",
       "stars": 5895,
@@ -1861,11 +1870,11 @@
       "tags": ["vdom", "framework"],
       "owner_id": 1961952,
       "icon": "rax.svg",
-      "created_at": "2016-10-14T07:53:50.000Z",
-      "slug": "rax"
+      "created_at": "2016-10-14T07:53:50.000Z"
     },
     {
       "name": "Ember",
+      "slug": "ember",
       "full_name": "emberjs/ember.js",
       "description": "Ember.js - A JavaScript framework for creating ambitious web applications",
       "stars": 21322,
@@ -1875,11 +1884,11 @@
       "owner_id": 1253363,
       "icon": "ember.svg",
       "created_at": "2011-05-25T23:39:40.000Z",
-      "url": "https://emberjs.com",
-      "slug": "ember"
+      "url": "https://emberjs.com"
     },
     {
       "name": "JSS",
+      "slug": "jss",
       "full_name": "cssinjs/jss",
       "description": "JSS is an authoring tool for CSS which uses JavaScript as a host language.",
       "stars": 5432,
@@ -1888,11 +1897,11 @@
       "tags": ["css-in-js"],
       "owner_id": 9503099,
       "created_at": "2014-10-12T20:33:53.000Z",
-      "url": "https://cssinjs.org",
-      "slug": "jss"
+      "url": "https://cssinjs.org"
     },
     {
       "name": "Node API boilerplate",
+      "slug": "node-api-boilerplate",
       "full_name": "talyssonoc/node-api-boilerplate",
       "description": "DDD/Clean Architecture inspired boilerplate for Node web APIs",
       "stars": 1952,
@@ -1900,11 +1909,11 @@
       "monthly": [137, 60, 67, 54, 89, 72, 58, 63, 53, 84, 82, 116],
       "tags": ["boilerplate", "nodejs-framework"],
       "owner_id": 4325587,
-      "created_at": "2017-03-13T21:16:09.000Z",
-      "slug": "node-api-boilerplate"
+      "created_at": "2017-03-13T21:16:09.000Z"
     },
     {
       "name": "NG Bootstrap",
+      "slug": "ng-bootstrap",
       "full_name": "ng-bootstrap/ng-bootstrap",
       "description": "Angular powered Bootstrap",
       "stars": 7306,
@@ -1913,11 +1922,11 @@
       "tags": ["angular", "component", "bootstrap"],
       "owner_id": 14283866,
       "created_at": "2015-09-14T22:55:53.000Z",
-      "url": "https://ng-bootstrap.github.io",
-      "slug": "ng-bootstrap"
+      "url": "https://ng-bootstrap.github.io"
     },
     {
       "name": "PrimeNG",
+      "slug": "primeng",
       "full_name": "primefaces/primeng",
       "description": "The Most Complete UI Component Library for Angular",
       "stars": 5741,
@@ -1926,11 +1935,11 @@
       "tags": ["angular", "component"],
       "owner_id": 3494069,
       "created_at": "2016-01-16T09:23:28.000Z",
-      "url": "https://www.primefaces.org/primeng",
-      "slug": "primeng"
+      "url": "https://www.primefaces.org/primeng"
     },
     {
       "name": "Meteor",
+      "slug": "meteor",
       "full_name": "meteor/meteor",
       "description": "Meteor, the JavaScript App Platform",
       "stars": 41524,
@@ -1940,11 +1949,11 @@
       "owner_id": 789528,
       "icon": "meteor.svg",
       "created_at": "2012-01-19T01:58:17.000Z",
-      "url": "https://www.meteor.com",
-      "slug": "meteor"
+      "url": "https://www.meteor.com"
     },
     {
       "name": "Gulp",
+      "slug": "gulp",
       "full_name": "gulpjs/gulp",
       "description": "The streaming build system",
       "stars": 31611,
@@ -1954,11 +1963,11 @@
       "owner_id": 6200624,
       "icon": "gulp.svg",
       "created_at": "2013-07-04T05:26:06.000Z",
-      "url": "http://gulpjs.com",
-      "slug": "gulp"
+      "url": "http://gulpjs.com"
     },
     {
       "name": "NGXS",
+      "slug": "ngxs",
       "full_name": "ngxs/store",
       "description": "NGXS - State Management for Angular",
       "stars": 2597,
@@ -1967,8 +1976,7 @@
       "tags": ["state", "angular"],
       "owner_id": 37132593,
       "created_at": "2018-02-13T18:55:44.000Z",
-      "url": "http://ngxs.io",
-      "slug": "ngxs"
+      "url": "http://ngxs.io"
     },
     {
       "name": "Loopback",
@@ -1980,12 +1988,13 @@
       "monthly": [46, 31, 43, 33, 28, 46, 25, 73, 105, 126, 105, 120],
       "tags": ["nodejs-framework"],
       "owner_id": 3020012,
-      "icon": "loopback.svg",
+      "icon": "loopback3.svg",
       "created_at": "2013-04-09T16:02:18.000Z",
       "url": "http://loopback.io"
     },
     {
       "name": "Hybrids",
+      "slug": "hybrids",
       "full_name": "hybridsjs/hybrids",
       "description": "UI library for creating web components with plain objects and pure functions",
       "stars": 1679,
@@ -1995,11 +2004,11 @@
       "owner_id": 22907385,
       "icon": "hybrids.svg",
       "created_at": "2016-12-06T20:19:43.000Z",
-      "url": "https://hybrids.js.org",
-      "slug": "hybrids"
+      "url": "https://hybrids.js.org"
     },
     {
       "name": "Inferno",
+      "slug": "inferno",
       "full_name": "infernojs/inferno",
       "description": "An extremely fast, React-like JavaScript library for building modern user interfaces",
       "stars": 14131,
@@ -2009,11 +2018,11 @@
       "owner_id": 14214240,
       "icon": "inferno.svg",
       "created_at": "2015-02-01T22:07:38.000Z",
-      "url": "https://infernojs.org",
-      "slug": "inferno"
+      "url": "https://infernojs.org"
     },
     {
       "name": "Polymer",
+      "slug": "polymer",
       "full_name": "Polymer/polymer",
       "description": "Our original Web Component library.",
       "stars": 21336,
@@ -2023,11 +2032,11 @@
       "owner_id": 2159051,
       "icon": "polymer.svg",
       "created_at": "2012-08-23T20:56:30.000Z",
-      "url": "https://polymer-library.polymer-project.org/",
-      "slug": "polymer"
+      "url": "https://polymer-library.polymer-project.org/"
     },
     {
       "name": "Polka",
+      "slug": "polka",
       "full_name": "lukeed/polka",
       "description": "A micro web server so fast, it'll make you dance!",
       "stars": 3547,
@@ -2035,8 +2044,7 @@
       "monthly": [31, 48, 42, 71, 59, 90, 88, 97, 47, 35, 49, 86],
       "tags": ["nodejs-framework"],
       "owner_id": 5855893,
-      "created_at": "2017-12-22T05:55:41.000Z",
-      "slug": "polka"
+      "created_at": "2017-12-22T05:55:41.000Z"
     }
   ],
   "tags": [

--- a/data/2020/projects.json
+++ b/data/2020/projects.json
@@ -2,6 +2,7 @@
   "projects": [
     {
       "name": "JS Algorithms & Data Structures",
+      "slug": "js-algorithms-and-data-structures",
       "full_name": "trekhleb/javascript-algorithms",
       "description": "Algorithms and data structures implemented in JavaScript with explanations and links to further readings",
       "stars": 92607,
@@ -12,11 +13,11 @@
       ],
       "tags": ["learning", "data-structure"],
       "owner_id": 3000285,
-      "created_at": "2018-03-24T07:47:04.000Z",
-      "slug": "js-algorithms-and-data-structures"
+      "created_at": "2018-03-24T07:47:04.000Z"
     },
     {
       "name": "Deno",
+      "slug": "deno",
       "full_name": "denoland/deno",
       "description": "A secure JavaScript and TypeScript runtime",
       "stars": 71135,
@@ -29,11 +30,11 @@
       "owner_id": 42048915,
       "icon": "deno.svg",
       "created_at": "2018-05-15T01:34:26.000Z",
-      "url": "https://deno.land",
-      "slug": "deno"
+      "url": "https://deno.land"
     },
     {
       "name": "Vue.js",
+      "slug": "vuejs-2",
       "full_name": "vuejs/vue",
       "description": "A progressive, incrementally-adoptable framework for building UI on the web",
       "stars": 177915,
@@ -46,12 +47,11 @@
       "owner_id": 6128107,
       "icon": "vue.svg",
       "created_at": "2013-07-29T03:24:51.000Z",
-      "url": "http://vuejs.org",
-      "slug": "vuejs-2",
-      "ref": "vuejs"
+      "url": "http://vuejs.org"
     },
     {
       "name": "Node.js Best Practices",
+      "slug": "nodejs-best-practices",
       "full_name": "goldbergyoni/nodebestpractices",
       "description": "The Node.js best practices list (January 2021)",
       "stars": 58873,
@@ -62,11 +62,11 @@
       ],
       "tags": ["learning"],
       "owner_id": 8571500,
-      "created_at": "2017-09-15T08:33:19.000Z",
-      "slug": "nodejs-best-practices"
+      "created_at": "2017-09-15T08:33:19.000Z"
     },
     {
       "name": "React",
+      "slug": "react",
       "full_name": "facebook/react",
       "description": "A declarative, efficient, and flexible JavaScript library for building user interfaces.",
       "stars": 161937,
@@ -79,11 +79,11 @@
       "owner_id": 69631,
       "icon": "react.svg",
       "created_at": "2013-05-24T16:15:54.000Z",
-      "url": "https://reactjs.org",
-      "slug": "react"
+      "url": "https://reactjs.org"
     },
     {
       "name": "Playwright",
+      "slug": "playwright",
       "full_name": "microsoft/playwright",
       "description": "Node.js library to automate Chromium, Firefox and WebKit with a single API",
       "stars": 20154,
@@ -95,11 +95,11 @@
       "owner_id": 6154722,
       "icon": "playwright.svg",
       "created_at": "2019-11-15T18:32:42.000Z",
-      "url": "https://playwright.dev",
-      "slug": "playwright"
+      "url": "https://playwright.dev"
     },
     {
       "name": "VS Code",
+      "slug": "vs-code",
       "full_name": "microsoft/vscode",
       "description": "Visual Studio Code",
       "stars": 109107,
@@ -112,11 +112,11 @@
       "owner_id": 6154722,
       "icon": "vscode.svg",
       "created_at": "2015-09-03T20:23:38.000Z",
-      "url": "https://code.visualstudio.com",
-      "slug": "vs-code"
+      "url": "https://code.visualstudio.com"
     },
     {
       "name": "You Don't Know JS",
+      "slug": "you-dont-know-js",
       "full_name": "getify/You-Dont-Know-JS",
       "description": "A book series on JavaScript",
       "stars": 132295,
@@ -128,11 +128,11 @@
       "tags": ["learning", "book"],
       "owner_id": 150330,
       "icon": "js.svg",
-      "created_at": "2013-11-16T02:37:24.000Z",
-      "slug": "you-dont-know-js"
+      "created_at": "2013-11-16T02:37:24.000Z"
     },
     {
       "name": "esbuild",
+      "slug": "esbuild",
       "full_name": "evanw/esbuild",
       "description": "An extremely fast JavaScript bundler and minifier",
       "stars": 16854,
@@ -142,11 +142,11 @@
       "owner_id": 406394,
       "icon": "esbuild.svg",
       "created_at": "2016-06-14T16:08:50.000Z",
-      "url": "https://esbuild.github.io/",
-      "slug": "esbuild"
+      "url": "https://esbuild.github.io/"
     },
     {
       "name": "Vue Element Admin",
+      "slug": "vue-element-admin",
       "full_name": "PanJiaChen/vue-element-admin",
       "description": "A magical vue admin",
       "stars": 63839,
@@ -158,11 +158,11 @@
       "tags": ["vue", "dashboard"],
       "owner_id": 8121621,
       "icon": "vueelementadmin.png",
-      "created_at": "2017-04-17T03:35:49.000Z",
-      "slug": "vue-element-admin"
+      "created_at": "2017-04-17T03:35:49.000Z"
     },
     {
       "name": "eDEX-UI",
+      "slug": "edex-ui",
       "full_name": "GitSquared/edex-ui",
       "description": "A cross-platform, customizable science fiction terminal emulator with advanced monitoring & touchscreen support.",
       "stars": 28047,
@@ -172,11 +172,11 @@
       ],
       "tags": ["cli"],
       "owner_id": 24496417,
-      "created_at": "2017-01-28T09:35:02.000Z",
-      "slug": "edex-ui"
+      "created_at": "2017-01-28T09:35:02.000Z"
     },
     {
       "name": "Next.js",
+      "slug": "nextjs",
       "full_name": "vercel/next.js",
       "description": "The React Framework",
       "stars": 59903,
@@ -196,11 +196,11 @@
       "owner_id": 14985020,
       "icon": "nextjs.svg",
       "created_at": "2016-10-05T23:32:51.000Z",
-      "url": "https://nextjs.org",
-      "slug": "nextjs"
+      "url": "https://nextjs.org"
     },
     {
       "name": "Tailwind CSS",
+      "slug": "tailwind-css",
       "full_name": "tailwindlabs/tailwindcss",
       "description": "A utility-first CSS framework for rapid UI development.",
       "stars": 34188,
@@ -213,11 +213,11 @@
       "owner_id": 67109815,
       "icon": "tailwindcss.svg",
       "created_at": "2017-10-06T14:59:14.000Z",
-      "url": "https://tailwindcss.com/",
-      "slug": "tailwind-css"
+      "url": "https://tailwindcss.com/"
     },
     {
       "name": "Clean Code",
+      "slug": "clean-code",
       "full_name": "ryanmcdermott/clean-code-javascript",
       "description": "Clean Code concepts adapted for JavaScript",
       "stars": 44343,
@@ -227,11 +227,11 @@
       ],
       "tags": ["learning"],
       "owner_id": 5114666,
-      "created_at": "2016-11-25T22:25:41.000Z",
-      "slug": "clean-code"
+      "created_at": "2016-11-25T22:25:41.000Z"
     },
     {
       "name": "Rome",
+      "slug": "rome",
       "full_name": "rome/tools",
       "description": "The Rome Toolchain. A linter, compiler, bundler, and more for JavaScript, TypeScript, HTML, Markdown, and CSS.",
       "stars": 14339,
@@ -241,11 +241,11 @@
       "owner_id": 44216277,
       "icon": "rome.svg",
       "created_at": "2020-02-20T05:57:33.000Z",
-      "url": "https://rome.tools/",
-      "slug": "rome"
+      "url": "https://rome.tools/"
     },
     {
       "name": "Vite",
+      "slug": "vite",
       "full_name": "vitejs/vite",
       "description": "Next generation frontend tooling. It's fast!",
       "stars": 15116,
@@ -255,7 +255,7 @@
       "owner_id": 65625612,
       "created_at": "2020-04-21T05:03:57.000Z",
       "url": "http://vitejs.dev/",
-      "slug": "vite"
+      "icon": "vite.svg"
     },
     {
       "name": "React Query",
@@ -275,6 +275,7 @@
     },
     {
       "name": "Angular",
+      "slug": "angular",
       "full_name": "angular/angular",
       "description": "One framework. Mobile & desktop.",
       "stars": 69740,
@@ -287,11 +288,11 @@
       "owner_id": 139426,
       "icon": "angular.svg",
       "created_at": "2014-09-18T16:12:01.000Z",
-      "url": "https://angular.io",
-      "slug": "angular"
+      "url": "https://angular.io"
     },
     {
       "name": "30 seconds of code",
+      "slug": "30-seconds-of-code",
       "full_name": "30-seconds/30-seconds-of-code",
       "description": "Short JavaScript code snippets for all your development needs",
       "stars": 67102,
@@ -302,11 +303,11 @@
       "tags": ["learning"],
       "owner_id": 43479428,
       "created_at": "2017-11-29T17:35:03.000Z",
-      "url": "https://www.30secondsofcode.org/js/p/1",
-      "slug": "30-seconds-of-code"
+      "url": "https://www.30secondsofcode.org/js/p/1"
     },
     {
       "name": "Storybook",
+      "slug": "storybook",
       "full_name": "storybookjs/storybook",
       "description": "The UI component explorer. Develop, document, & test for React, Vue, Angular, Ember, Web Components, & more!",
       "stars": 57242,
@@ -318,11 +319,11 @@
       "owner_id": 22632046,
       "icon": "storybook.svg",
       "created_at": "2016-03-18T04:23:44.000Z",
-      "url": "https://storybook.js.org",
-      "slug": "storybook"
+      "url": "https://storybook.js.org"
     },
     {
       "name": "Axios",
+      "slug": "axios",
       "full_name": "axios/axios",
       "description": "Promise based HTTP client for the browser and node.js",
       "stars": 80589,
@@ -333,10 +334,11 @@
       "tags": ["http"],
       "owner_id": 32372333,
       "created_at": "2014-08-18T22:30:27.000Z",
-      "slug": "axios"
+      "icon": "axios.svg"
     },
     {
       "name": "Svelte",
+      "slug": "svelte",
       "full_name": "sveltejs/svelte",
       "description": "Cybernetically enhanced web apps",
       "stars": 40973,
@@ -348,11 +350,11 @@
       "owner_id": 23617963,
       "icon": "svelte.svg",
       "created_at": "2016-11-20T18:13:05.000Z",
-      "url": "https://svelte.dev",
-      "slug": "svelte"
+      "url": "https://svelte.dev"
     },
     {
       "name": "Strapi",
+      "slug": "strapi",
       "full_name": "strapi/strapi",
       "description": "Open source Node.js Headless CMS to easily build customisable APIs",
       "stars": 32650,
@@ -364,11 +366,11 @@
       "owner_id": 19872173,
       "icon": "strapi.svg",
       "created_at": "2015-09-30T15:34:48.000Z",
-      "url": "https://strapi.io",
-      "slug": "strapi"
+      "url": "https://strapi.io"
     },
     {
       "name": "Airbnb Style Guide",
+      "slug": "airbnb-style-guide",
       "full_name": "airbnb/javascript",
       "description": "JavaScript Style Guide",
       "stars": 103608,
@@ -378,11 +380,11 @@
       ],
       "tags": ["learning"],
       "owner_id": 698437,
-      "created_at": "2012-11-01T23:13:50.000Z",
-      "slug": "airbnb-style-guide"
+      "created_at": "2012-11-01T23:13:50.000Z"
     },
     {
       "name": "Alpine.js",
+      "slug": "alpinejs",
       "full_name": "alpinejs/alpine",
       "description": "A rugged, minimal framework for composing JavaScript behavior in your markup.",
       "stars": 12969,
@@ -393,11 +395,11 @@
       "tags": ["framework"],
       "owner_id": 59030169,
       "icon": "alpine.svg",
-      "created_at": "2019-11-28T13:51:55.000Z",
-      "slug": "alpinejs"
+      "created_at": "2019-11-28T13:51:55.000Z"
     },
     {
       "name": "Recoil",
+      "slug": "recoil",
       "full_name": "facebookexperimental/Recoil",
       "description": "An experimental state management library for React apps",
       "stars": 11223,
@@ -407,11 +409,11 @@
       "owner_id": 12853545,
       "icon": "recoil.svg",
       "created_at": "2020-05-04T19:44:15.000Z",
-      "url": "http://recoiljs.org/",
-      "slug": "recoil"
+      "url": "http://recoiljs.org/"
     },
     {
       "name": "Ant Design",
+      "slug": "ant-design",
       "full_name": "ant-design/ant-design",
       "description": "A UI Design Language and React UI library",
       "stars": 66049,
@@ -423,11 +425,11 @@
       "owner_id": 12101536,
       "icon": "ant.svg",
       "created_at": "2015-04-24T15:37:24.000Z",
-      "url": "https://ant.design",
-      "slug": "ant-design"
+      "url": "https://ant.design"
     },
     {
       "name": "React Hook Form",
+      "slug": "react-hook-form",
       "full_name": "react-hook-form/react-hook-form",
       "description": "React Hooks for forms validation (Web + React Native)",
       "stars": 16795,
@@ -439,11 +441,11 @@
       "owner_id": 53986236,
       "icon": "react-hook-form.svg",
       "created_at": "2019-03-05T23:47:10.000Z",
-      "url": "https://react-hook-form.com",
-      "slug": "react-hook-form"
+      "url": "https://react-hook-form.com"
     },
     {
       "name": "Heroicons",
+      "slug": "heroicons",
       "full_name": "tailwindlabs/heroicons",
       "description": "A set of free MIT-licensed high-quality SVG icons for UI development.",
       "stars": 10949,
@@ -453,11 +455,11 @@
       "owner_id": 67109815,
       "icon": "heroicons.svg",
       "created_at": "2020-02-24T14:16:00.000Z",
-      "url": "https://heroicons.com",
-      "slug": "heroicons"
+      "url": "https://heroicons.com"
     },
     {
       "name": "Tech Interview Handbook",
+      "slug": "tech-interview-handbook",
       "full_name": "yangshun/tech-interview-handbook",
       "description": "Materials to help you rock your next coding interview",
       "stars": 49258,
@@ -470,11 +472,11 @@
       "owner_id": 1315101,
       "icon": "tech-interview.svg",
       "created_at": "2016-07-05T05:00:48.000Z",
-      "url": "https://yangshun.github.io/tech-interview-handbook/",
-      "slug": "tech-interview-handbook"
+      "url": "https://yangshun.github.io/tech-interview-handbook/"
     },
     {
       "name": "Material UI",
+      "slug": "material-ui",
       "full_name": "mui-org/material-ui",
       "description": "React components for faster and simpler web development. Build your own design system, or start with Material Design.",
       "stars": 64221,
@@ -486,11 +488,11 @@
       "owner_id": 33663932,
       "icon": "material-ui.svg",
       "created_at": "2014-08-18T19:11:54.000Z",
-      "url": "https://material-ui.com/",
-      "slug": "material-ui"
+      "url": "https://material-ui.com/"
     },
     {
       "name": "Puppeteer",
+      "slug": "puppeteer",
       "full_name": "puppeteer/puppeteer",
       "description": "Headless Chrome Node.js API",
       "stars": 68043,
@@ -502,11 +504,11 @@
       "owner_id": 6906516,
       "icon": "puppeteer.svg",
       "created_at": "2017-05-09T22:16:13.000Z",
-      "url": "https://pptr.dev/",
-      "slug": "puppeteer"
+      "url": "https://pptr.dev/"
     },
     {
       "name": "TypeScript",
+      "slug": "typescript",
       "full_name": "microsoft/TypeScript",
       "description": "A superset of JavaScript that compiles to clean JavaScript output.",
       "stars": 67641,
@@ -518,11 +520,11 @@
       "owner_id": 6154722,
       "icon": "typescript.svg",
       "created_at": "2014-06-17T15:28:39.000Z",
-      "url": "https://www.typescriptlang.org",
-      "slug": "typescript"
+      "url": "https://www.typescriptlang.org"
     },
     {
       "name": "freeCodeCamp",
+      "slug": "freecodecamp",
       "full_name": "freeCodeCamp/freeCodeCamp",
       "description": "freeCodeCamp.org's open source codebase and curriculum. Learn to code at home.",
       "stars": 318497,
@@ -532,11 +534,11 @@
       ],
       "tags": ["learning"],
       "owner_id": 9892522,
-      "created_at": "2014-12-24T17:49:19.000Z",
-      "slug": "freecodecamp"
+      "created_at": "2014-12-24T17:49:19.000Z"
     },
     {
       "name": "Nest",
+      "slug": "nest",
       "full_name": "nestjs/nest",
       "description": "A progressive Node.js framework for building efficient, scalable, and enterprise-grade server-side applications on top of TypeScript & JavaScript (ES6, ES7, ES8)",
       "stars": 33551,
@@ -548,11 +550,11 @@
       "owner_id": 28507035,
       "icon": "nest.svg",
       "created_at": "2017-02-04T20:12:52.000Z",
-      "url": "https://nestjs.com",
-      "slug": "nest"
+      "url": "https://nestjs.com"
     },
     {
       "name": "Create React App",
+      "slug": "create-react-app",
       "full_name": "facebook/create-react-app",
       "description": "Set up a modern web app by running one command.",
       "stars": 85157,
@@ -564,11 +566,11 @@
       "owner_id": 69631,
       "icon": "cra.svg",
       "created_at": "2016-07-17T14:55:11.000Z",
-      "url": "https://create-react-app.dev",
-      "slug": "create-react-app"
+      "url": "https://create-react-app.dev"
     },
     {
       "name": "Snowpack",
+      "slug": "snowpack",
       "full_name": "snowpackjs/snowpack",
       "description": "WASM-powered frontend build tool. Fast, lightweight, unbundled ESM.",
       "stars": 15198,
@@ -580,11 +582,11 @@
       "owner_id": 44914786,
       "icon": "snowpack.svg",
       "created_at": "2019-02-26T15:45:38.000Z",
-      "url": "https://www.snowpack.dev",
-      "slug": "snowpack"
+      "url": "https://www.snowpack.dev"
     },
     {
       "name": "Chakra UI",
+      "slug": "chakra-ui",
       "full_name": "chakra-ui/chakra-ui",
       "description": "️ Simple, Modular & Accessible UI Components for your React Applications",
       "stars": 14287,
@@ -596,11 +598,11 @@
       "owner_id": 54212428,
       "icon": "chakra-ui.svg",
       "created_at": "2019-08-17T14:27:54.000Z",
-      "url": "https://chakra-ui.com",
-      "slug": "chakra-ui"
+      "url": "https://chakra-ui.com"
     },
     {
       "name": "Tabler Icons",
+      "slug": "tabler-icons",
       "full_name": "tabler/tabler-icons",
       "description": "A set of over 950 free MIT-licensed high-quality SVG icons for you to use in your web projects.",
       "stars": 9651,
@@ -609,11 +611,11 @@
       "tags": ["icon"],
       "owner_id": 35471246,
       "created_at": "2020-02-27T15:10:04.000Z",
-      "url": "https://tablericons.com/",
-      "slug": "tabler-icons"
+      "url": "https://tablericons.com/"
     },
     {
       "name": "Front-End Checklist",
+      "slug": "front-end-checklist",
       "full_name": "thedaviddias/Front-End-Checklist",
       "description": "The perfect Front-End Checklist for modern websites and meticulous developers",
       "stars": 46439,
@@ -625,11 +627,11 @@
       "owner_id": 237229,
       "icon": "frontendchecklist.jpg",
       "created_at": "2017-10-16T10:12:36.000Z",
-      "url": "https://frontendchecklist.io",
-      "slug": "front-end-checklist"
+      "url": "https://frontendchecklist.io"
     },
     {
       "name": "Cypress",
+      "slug": "cypress",
       "full_name": "cypress-io/cypress",
       "description": "Fast, easy and reliable testing for anything that runs in a browser.",
       "stars": 26379,
@@ -641,11 +643,11 @@
       "owner_id": 8908513,
       "icon": "cypress.svg",
       "created_at": "2015-03-04T00:46:28.000Z",
-      "url": "https://www.cypress.io",
-      "slug": "cypress"
+      "url": "https://www.cypress.io"
     },
     {
       "name": "swr",
+      "slug": "swr",
       "full_name": "vercel/swr",
       "description": "React Hooks library for remote data fetching",
       "stars": 15066,
@@ -657,11 +659,11 @@
       "owner_id": 14985020,
       "icon": "swr.svg",
       "created_at": "2019-10-28T18:16:01.000Z",
-      "url": "https://swr.vercel.app",
-      "slug": "swr"
+      "url": "https://swr.vercel.app"
     },
     {
       "name": "Node.js",
+      "slug": "nodejs",
       "full_name": "nodejs/node",
       "description": "Node.js JavaScript runtime",
       "stars": 75916,
@@ -673,11 +675,11 @@
       "owner_id": 9950313,
       "icon": "nodejs.svg",
       "created_at": "2014-11-26T19:57:11.000Z",
-      "url": "https://nodejs.org/",
-      "slug": "nodejs"
+      "url": "https://nodejs.org/"
     },
     {
       "name": "React Native",
+      "slug": "react-native",
       "full_name": "facebook/react-native",
       "description": "A framework for building native apps with React.",
       "stars": 92699,
@@ -689,11 +691,11 @@
       "owner_id": 69631,
       "icon": "react-native.svg",
       "created_at": "2015-01-09T18:10:16.000Z",
-      "url": "https://reactnative.dev/",
-      "slug": "react-native"
+      "url": "https://reactnative.dev/"
     },
     {
       "name": "Electron",
+      "slug": "electron",
       "full_name": "electron/electron",
       "description": "Build cross-platform desktop apps with JavaScript, HTML, and CSS",
       "stars": 88655,
@@ -705,11 +707,11 @@
       "owner_id": 13409222,
       "icon": "electron.svg",
       "created_at": "2013-04-12T01:47:36.000Z",
-      "url": "https://electronjs.org",
-      "slug": "electron"
+      "url": "https://electronjs.org"
     },
     {
       "name": "Three.js",
+      "slug": "threejs",
       "full_name": "mrdoob/three.js",
       "description": "JavaScript 3D library.",
       "stars": 66281,
@@ -721,10 +723,11 @@
       "owner_id": 97088,
       "created_at": "2010-03-23T18:58:01.000Z",
       "url": "https://threejs.org/",
-      "slug": "threejs"
+      "icon": "threejs.svg"
     },
     {
       "name": "Bootstrap",
+      "slug": "bootstrap",
       "full_name": "twbs/bootstrap",
       "description": "The most popular HTML, CSS, and JavaScript framework for developing responsive, mobile first projects on the web.",
       "stars": 146351,
@@ -736,11 +739,11 @@
       "owner_id": 2918581,
       "icon": "bootstrap.svg",
       "created_at": "2011-07-29T21:19:00.000Z",
-      "url": "https://getbootstrap.com",
-      "slug": "bootstrap"
+      "url": "https://getbootstrap.com"
     },
     {
       "name": "Nuxt",
+      "slug": "nuxt",
       "full_name": "nuxt/nuxt.js",
       "description": "The Intuitive Vue Framework",
       "stars": 33001,
@@ -752,11 +755,11 @@
       "owner_id": 23360933,
       "icon": "nuxt.svg",
       "created_at": "2016-10-26T11:18:47.000Z",
-      "url": "https://nuxtjs.org",
-      "slug": "nuxt"
+      "url": "https://nuxtjs.org"
     },
     {
       "name": "Vanilla Web Projects",
+      "slug": "vanilla-web-projects",
       "full_name": "bradtraversy/vanillawebprojects",
       "description": "Mini projects built with HTML5, CSS & JavaScript. No frameworks or libraries",
       "stars": 8270,
@@ -764,11 +767,11 @@
       "monthly": [136, 117, 150, 380, 196, 576, 1256],
       "tags": ["learning"],
       "owner_id": 5550850,
-      "created_at": "2020-01-28T14:11:32.000Z",
-      "slug": "vanilla-web-projects"
+      "created_at": "2020-01-28T14:11:32.000Z"
     },
     {
       "name": "react-use",
+      "slug": "react-use",
       "full_name": "streamich/react-use",
       "description": "Collection of essential React Hooks",
       "stars": 17935,
@@ -779,11 +782,11 @@
       "tags": ["react"],
       "owner_id": 9773803,
       "created_at": "2018-10-27T10:16:05.000Z",
-      "url": "http://streamich.github.io/react-use",
-      "slug": "react-use"
+      "url": "http://streamich.github.io/react-use"
     },
     {
       "name": "Gatsby",
+      "slug": "gatsby",
       "full_name": "gatsbyjs/gatsby",
       "description": "Build blazing fast, modern apps and websites with React",
       "stars": 48613,
@@ -795,11 +798,11 @@
       "owner_id": 12551863,
       "icon": "gatsby.svg",
       "created_at": "2015-05-21T22:43:05.000Z",
-      "url": "https://www.gatsbyjs.com",
-      "slug": "gatsby"
+      "url": "https://www.gatsbyjs.com"
     },
     {
       "name": "Element Plus",
+      "slug": "element-plus",
       "full_name": "element-plus/element-plus",
       "description": "A Vue.js 3.0 UI Library made by Element team",
       "stars": 7579,
@@ -808,11 +811,11 @@
       "tags": ["component", "vue"],
       "owner_id": 68583457,
       "created_at": "2020-07-21T06:51:19.000Z",
-      "url": "https://element-plus.org/",
-      "slug": "element-plus"
+      "url": "https://element-plus.org/"
     },
     {
       "name": "json-server",
+      "slug": "json-server",
       "full_name": "typicode/json-server",
       "description": "Get a full fake REST API with zero coding in less than 30 seconds (seriously)",
       "stars": 51468,
@@ -822,11 +825,11 @@
       ],
       "tags": ["test", "filesystem"],
       "owner_id": 5502029,
-      "created_at": "2013-11-27T13:21:13.000Z",
-      "slug": "json-server"
+      "created_at": "2013-11-27T13:21:13.000Z"
     },
     {
       "name": "Docusaurus",
+      "slug": "docusaurus",
       "full_name": "facebook/docusaurus",
       "description": "Easy to maintain open source documentation websites.",
       "stars": 21051,
@@ -838,11 +841,11 @@
       "owner_id": 69631,
       "icon": "docusaurus.svg",
       "created_at": "2017-06-20T16:13:53.000Z",
-      "url": "https://docusaurus.io",
-      "slug": "docusaurus"
+      "url": "https://docusaurus.io"
     },
     {
       "name": "Headless Recorder",
+      "slug": "headless-recorder",
       "full_name": "checkly/headless-recorder",
       "description": "a Chrome extension that records your browser interactions and generates a Puppeteer or Playwright script",
       "stars": 12580,
@@ -853,11 +856,11 @@
       "tags": ["auto"],
       "owner_id": 25982255,
       "created_at": "2018-08-13T19:31:11.000Z",
-      "url": "https://checklyhq.com/headless-recorder",
-      "slug": "headless-recorder"
+      "url": "https://checklyhq.com/headless-recorder"
     },
     {
       "name": "Blitz",
+      "slug": "blitz",
       "full_name": "blitz-js/blitz",
       "description": "️The Fullstack React Framework — built on Next.js",
       "stars": 6086,
@@ -866,11 +869,11 @@
       "tags": ["fullstack", "react", "nodejs-framework"],
       "owner_id": 61243378,
       "created_at": "2020-02-17T21:54:15.000Z",
-      "url": "https://Blitzjs.com",
-      "slug": "blitz"
+      "url": "https://Blitzjs.com"
     },
     {
       "name": "Formik",
+      "slug": "formik",
       "full_name": "formium/formik",
       "description": "Build forms in React, without the tears",
       "stars": 25885,
@@ -882,11 +885,11 @@
       "owner_id": 50745844,
       "icon": "formik.svg",
       "created_at": "2017-06-14T19:50:59.000Z",
-      "url": "https://formik.org",
-      "slug": "formik"
+      "url": "https://formik.org"
     },
     {
       "name": "Hasura GraphQL Engine",
+      "slug": "hasura-graphql-engine",
       "full_name": "hasura/graphql-engine",
       "description": "Blazing fast, instant realtime GraphQL APIs on Postgres with fine grained access control, also trigger webhooks on database events.",
       "stars": 19868,
@@ -898,13 +901,11 @@
       "owner_id": 13966722,
       "icon": "hasura.svg",
       "created_at": "2018-06-18T07:57:36.000Z",
-      "url": "https://hasura.io",
-      "slug": "hasura-graphql-engine"
+      "url": "https://hasura.io"
     },
     {
       "name": "vue-next",
       "slug": "vuejs",
-      "ref": "vue-next",
       "full_name": "vuejs/vue-next",
       "description": "Vue.js is a progressive, incrementally-adoptable JavaScript framework for building UI on the web.",
       "stars": 20022,
@@ -913,10 +914,12 @@
       "tags": ["vue", "framework"],
       "owner_id": 6128107,
       "created_at": "2018-06-12T13:49:36.000Z",
-      "url": "https://v3.vuejs.org/"
+      "url": "https://v3.vuejs.org/",
+      "icon": "vue.svg"
     },
     {
       "name": "Vuetify",
+      "slug": "vuetify",
       "full_name": "vuetifyjs/vuetify",
       "description": "Material Component Framework for Vue",
       "stars": 29117,
@@ -928,11 +931,11 @@
       "owner_id": 22138497,
       "icon": "vuetify.svg",
       "created_at": "2016-09-12T00:39:35.000Z",
-      "url": "https://vuetifyjs.com",
-      "slug": "vuetify"
+      "url": "https://vuetifyjs.com"
     },
     {
       "name": "Wiki.js",
+      "slug": "wikijs",
       "full_name": "Requarks/wiki",
       "description": "A modern, lightweight and powerful wiki app built on Node.js",
       "stars": 11994,
@@ -943,11 +946,11 @@
       "tags": ["doc", "vue"],
       "owner_id": 16729233,
       "created_at": "2016-08-16T19:35:26.000Z",
-      "url": "https://wiki.js.org",
-      "slug": "wikijs"
+      "url": "https://wiki.js.org"
     },
     {
       "name": "Redwood",
+      "slug": "redwood",
       "full_name": "redwoodjs/redwood",
       "description": "Bringing full-stack to the Jamstack.",
       "stars": 6117,
@@ -957,11 +960,11 @@
       "owner_id": 45050444,
       "icon": "redwood.svg",
       "created_at": "2019-06-09T20:17:57.000Z",
-      "url": "https://redwoodjs.com",
-      "slug": "redwood"
+      "url": "https://redwoodjs.com"
     },
     {
       "name": "Element",
+      "slug": "element",
       "full_name": "ElemeFE/element",
       "description": "A Vue.js 2.0 UI Toolkit for Web",
       "stars": 48825,
@@ -973,11 +976,11 @@
       "owner_id": 12810740,
       "icon": "element.svg",
       "created_at": "2016-09-03T06:19:26.000Z",
-      "url": "https://element.eleme.io/",
-      "slug": "element"
+      "url": "https://element.eleme.io/"
     },
     {
       "name": "visx",
+      "slug": "visx",
       "full_name": "airbnb/visx",
       "description": "A collection of expressive, low-level visualization primitives for React",
       "stars": 12172,
@@ -989,8 +992,7 @@
       "owner_id": 698437,
       "icon": "visx.svg",
       "created_at": "2017-03-15T16:25:41.000Z",
-      "url": "https://airbnb.io/visx",
-      "slug": "visx"
+      "url": "https://airbnb.io/visx"
     },
     {
       "name": "Motion",
@@ -1010,6 +1012,7 @@
     },
     {
       "name": "XState",
+      "slug": "xstate",
       "full_name": "davidkpiano/xstate",
       "description": "State machines and statecharts for the modern web.",
       "stars": 14266,
@@ -1021,11 +1024,11 @@
       "owner_id": 1093738,
       "icon": "xstate.svg",
       "created_at": "2015-09-14T15:04:15.000Z",
-      "url": "https://xstate.js.org/docs",
-      "slug": "xstate"
+      "url": "https://xstate.js.org/docs"
     },
     {
       "name": "react-three-fiber",
+      "slug": "react-three-fiber",
       "full_name": "pmndrs/react-three-fiber",
       "description": "A React renderer for Three.js (web and react-native)",
       "stars": 11384,
@@ -1035,11 +1038,11 @@
       ],
       "tags": ["react", "3d"],
       "owner_id": 45790596,
-      "created_at": "2019-02-25T14:31:51.000Z",
-      "slug": "react-three-fiber"
+      "created_at": "2019-02-25T14:31:51.000Z"
     },
     {
       "name": "Styled Components",
+      "slug": "styled-components",
       "full_name": "styled-components/styled-components",
       "description": "Visual primitives for the component age. Use the best bits of ES6 and CSS to style your apps without stress",
       "stars": 32163,
@@ -1050,11 +1053,11 @@
       "tags": ["css-in-js"],
       "owner_id": 20658825,
       "created_at": "2016-08-16T06:41:32.000Z",
-      "url": "https://styled-components.com",
-      "slug": "styled-components"
+      "url": "https://styled-components.com"
     },
     {
       "name": "react-admin",
+      "slug": "react-admin",
       "full_name": "marmelab/react-admin",
       "description": "A frontend Framework for building B2B applications running in the browser on top of REST/GraphQL APIs, using ES6, React and Material Design",
       "stars": 15643,
@@ -1065,11 +1068,11 @@
       "tags": ["dashboard", "react", "redux", "material"],
       "owner_id": 3116319,
       "created_at": "2016-07-13T07:58:54.000Z",
-      "url": "http://marmelab.com/react-admin",
-      "slug": "react-admin"
+      "url": "http://marmelab.com/react-admin"
     },
     {
       "name": "Jest",
+      "slug": "jest",
       "full_name": "facebook/jest",
       "description": "Delightful JavaScript Testing.",
       "stars": 33793,
@@ -1081,11 +1084,11 @@
       "owner_id": 69631,
       "icon": "jest.svg",
       "created_at": "2013-12-10T00:18:04.000Z",
-      "url": "https://jestjs.io",
-      "slug": "jest"
+      "url": "https://jestjs.io"
     },
     {
       "name": "Express",
+      "slug": "express",
       "full_name": "expressjs/express",
       "description": "Fast, unopinionated, minimalist web framework for node.",
       "stars": 51495,
@@ -1097,11 +1100,11 @@
       "owner_id": 5658226,
       "icon": "express.svg",
       "created_at": "2009-06-26T18:56:01.000Z",
-      "url": "https://expressjs.com",
-      "slug": "express"
+      "url": "https://expressjs.com"
     },
     {
       "name": "Webpack",
+      "slug": "webpack",
       "full_name": "webpack/webpack",
       "description": "A bundler for javascript and friends. Packs many modules into a few bundled assets. Code Splitting allows for loading parts of the application on demand. Through \"loaders\", modules can be CommonJs, AMD, ES6 modules, CSS, Images, JSON, Coffeescript, LESS, ... and your custom stuff.",
       "stars": 56995,
@@ -1113,11 +1116,11 @@
       "owner_id": 2105791,
       "icon": "webpack.svg",
       "created_at": "2012-03-10T10:08:14.000Z",
-      "url": "https://webpack.js.org",
-      "slug": "webpack"
+      "url": "https://webpack.js.org"
     },
     {
       "name": "Expo",
+      "slug": "expo",
       "full_name": "expo/expo",
       "description": "An open-source platform for making universal native apps with React. Expo runs on Android, iOS, and the web.",
       "stars": 12654,
@@ -1129,11 +1132,11 @@
       "owner_id": 12504344,
       "icon": "expo.svg",
       "created_at": "2016-08-15T17:14:25.000Z",
-      "url": "https://docs.expo.io",
-      "slug": "expo"
+      "url": "https://docs.expo.io"
     },
     {
       "name": "Ant Design Vue",
+      "slug": "ant-design-vue",
       "full_name": "vueComponent/ant-design-vue",
       "description": "An enterprise-class UI components based on Ant Design and Vue.",
       "stars": 13412,
@@ -1145,11 +1148,11 @@
       "owner_id": 32120805,
       "icon": "antvue.svg",
       "created_at": "2017-09-20T06:04:01.000Z",
-      "url": "https://antdv.com/",
-      "slug": "ant-design-vue"
+      "url": "https://antdv.com/"
     },
     {
       "name": "Bulma",
+      "slug": "bulma",
       "full_name": "jgthms/bulma",
       "description": "Modern CSS framework based on Flexbox",
       "stars": 42289,
@@ -1161,11 +1164,11 @@
       "owner_id": 1254808,
       "icon": "bulma.svg",
       "created_at": "2016-01-23T23:48:34.000Z",
-      "url": "https://bulma.io",
-      "slug": "bulma"
+      "url": "https://bulma.io"
     },
     {
       "name": "Immer",
+      "slug": "immer",
       "full_name": "immerjs/immer",
       "description": "Create the next immutable state by mutating the current one",
       "stars": 18934,
@@ -1177,11 +1180,11 @@
       "owner_id": 45853199,
       "icon": "immer.svg",
       "created_at": "2017-12-29T12:25:47.000Z",
-      "url": "https://immerjs.github.io/immer/",
-      "slug": "immer"
+      "url": "https://immerjs.github.io/immer/"
     },
     {
       "name": "Vant",
+      "slug": "vant",
       "full_name": "youzan/vant",
       "description": "Lightweight Mobile UI Components built on Vue",
       "stars": 16446,
@@ -1192,11 +1195,11 @@
       "tags": ["vue", "component"],
       "owner_id": 11404085,
       "created_at": "2017-04-19T07:55:31.000Z",
-      "url": "https://vant-contrib.gitee.io/vant",
-      "slug": "vant"
+      "url": "https://vant-contrib.gitee.io/vant"
     },
     {
       "name": "Quasar",
+      "slug": "quasar",
       "full_name": "quasarframework/quasar",
       "description": "Responsive Single Page Apps, Server-side Render Apps, Progressive Web Apps, Hybrid Mobile Apps (that look native!) & Electron Apps, all using the same codebase.",
       "stars": 17300,
@@ -1208,10 +1211,11 @@
       "owner_id": 23064371,
       "created_at": "2015-10-05T15:45:36.000Z",
       "url": "https://quasar.dev",
-      "slug": "quasar"
+      "icon": "quasar.svg"
     },
     {
       "name": "Prisma",
+      "slug": "prisma",
       "full_name": "prisma/prisma",
       "description": "Next-generation ORM for Node.js & TypeScript | PostgreSQL, MySQL, MariaDB, SQL Server & SQLite",
       "stars": 7381,
@@ -1221,11 +1225,11 @@
       "owner_id": 17219288,
       "icon": "prisma.svg",
       "created_at": "2019-06-20T13:33:47.000Z",
-      "url": "https://www.prisma.io",
-      "slug": "prisma"
+      "url": "https://www.prisma.io"
     },
     {
       "name": "Fastify",
+      "slug": "fastify",
       "full_name": "fastify/fastify",
       "description": "Fast and low overhead web framework, for Node.js",
       "stars": 16930,
@@ -1237,11 +1241,11 @@
       "owner_id": 24939410,
       "icon": "fastify.svg",
       "created_at": "2016-09-28T19:10:14.000Z",
-      "url": "https://www.fastify.io",
-      "slug": "fastify"
+      "url": "https://www.fastify.io"
     },
     {
       "name": "Headless UI",
+      "slug": "headless-ui",
       "full_name": "tailwindlabs/headlessui",
       "description": "Completely unstyled, fully accessible UI components, designed to integrate beautifully with Tailwind CSS.",
       "stars": 3933,
@@ -1251,11 +1255,11 @@
       "owner_id": 67109815,
       "icon": "headlessui.svg",
       "created_at": "2020-09-16T09:53:09.000Z",
-      "url": "https://headlessui.dev",
-      "slug": "headless-ui"
+      "url": "https://headlessui.dev"
     },
     {
       "name": "TSdx",
+      "slug": "tsdx",
       "full_name": "formium/tsdx",
       "description": "Zero-config CLI for TypeScript package development",
       "stars": 7232,
@@ -1266,11 +1270,11 @@
       "tags": ["scaffolding", "build"],
       "owner_id": 50745844,
       "created_at": "2019-01-24T13:04:18.000Z",
-      "url": "https://tsdx.io",
-      "slug": "tsdx"
+      "url": "https://tsdx.io"
     },
     {
       "name": "swc",
+      "slug": "swc",
       "full_name": "swc-project/swc",
       "description": "A super-fast compiler written in rust",
       "stars": 10236,
@@ -1280,10 +1284,11 @@
       "owner_id": 26715726,
       "created_at": "2017-12-22T11:40:14.000Z",
       "url": "https://swc.rs",
-      "slug": "swc"
+      "icon": "swc.svg"
     },
     {
       "name": "Solid",
+      "slug": "solid",
       "full_name": "ryansolid/solid",
       "description": "A declarative, efficient, and flexible JavaScript library for building user interfaces.",
       "stars": 4897,
@@ -1294,10 +1299,11 @@
       "tags": ["reactive", "framework"],
       "owner_id": 2768267,
       "created_at": "2018-04-24T16:36:27.000Z",
-      "slug": "solid"
+      "icon": "solid.svg"
     },
     {
       "name": "react-testing-library",
+      "slug": "react-testing-library",
       "full_name": "testing-library/react-testing-library",
       "description": "Simple and complete React DOM testing utilities that encourage good testing practices.",
       "stars": 13536,
@@ -1308,11 +1314,11 @@
       "tags": ["test", "react"],
       "owner_id": 49996085,
       "created_at": "2018-03-19T13:39:49.000Z",
-      "url": "https://testing-library.com/react",
-      "slug": "react-testing-library"
+      "url": "https://testing-library.com/react"
     },
     {
       "name": "Zustand",
+      "slug": "zustand",
       "full_name": "pmndrs/zustand",
       "description": "Bear necessities for state management in React",
       "stars": 5949,
@@ -1322,10 +1328,11 @@
       "owner_id": 45790596,
       "created_at": "2019-04-09T09:10:06.000Z",
       "url": "https://zustand.surge.sh",
-      "slug": "zustand"
+      "icon": "zustand.webp"
     },
     {
       "name": "Parcel",
+      "slug": "parcel",
       "full_name": "parcel-bundler/parcel",
       "description": "Blazing fast, zero configuration web application bundler",
       "stars": 37440,
@@ -1337,11 +1344,11 @@
       "owner_id": 32607881,
       "icon": "parcel.svg",
       "created_at": "2017-08-07T16:36:47.000Z",
-      "url": "https://parceljs.org",
-      "slug": "parcel"
+      "url": "https://parceljs.org"
     },
     {
       "name": "Redux",
+      "slug": "redux",
       "full_name": "reduxjs/redux",
       "description": "Predictable state container for JavaScript apps",
       "stars": 55061,
@@ -1353,11 +1360,11 @@
       "owner_id": 13142323,
       "icon": "redux.svg",
       "created_at": "2015-05-29T23:53:15.000Z",
-      "url": "https://redux.js.org",
-      "slug": "redux"
+      "url": "https://redux.js.org"
     },
     {
       "name": "wmr",
+      "slug": "wmr",
       "full_name": "preactjs/wmr",
       "description": "The tiny all-in-one development tool for modern web apps.",
       "stars": 3160,
@@ -1365,11 +1372,11 @@
       "monthly": [2836],
       "tags": ["build", "universal", "prefetch"],
       "owner_id": 26872990,
-      "created_at": "2020-05-21T22:19:03.000Z",
-      "slug": "wmr"
+      "created_at": "2020-05-21T22:19:03.000Z"
     },
     {
       "name": "new.css",
+      "slug": "newcss",
       "full_name": "xz/new.css",
       "description": "A classless CSS framework to write modern websites using only HTML.",
       "stars": 3130,
@@ -1378,11 +1385,11 @@
       "tags": ["css-lib"],
       "owner_id": 58664567,
       "created_at": "2020-05-03T03:18:57.000Z",
-      "url": "https://newcss.net",
-      "slug": "newcss"
+      "url": "https://newcss.net"
     },
     {
       "name": "Vuex",
+      "slug": "vuex",
       "full_name": "vuejs/vuex",
       "description": "Centralized State Management for Vue.js.",
       "stars": 25519,
@@ -1393,11 +1400,11 @@
       "tags": ["flux", "vue", "state"],
       "owner_id": 6128107,
       "created_at": "2015-07-16T04:21:26.000Z",
-      "url": "https://vuex.vuejs.org",
-      "slug": "vuex"
+      "url": "https://vuex.vuejs.org"
     },
     {
       "name": "Preact",
+      "slug": "preact",
       "full_name": "preactjs/preact",
       "description": "Fast 3kB React alternative with the same modern API. Components & Virtual DOM.",
       "stars": 28037,
@@ -1409,11 +1416,11 @@
       "owner_id": 26872990,
       "icon": "preact.svg",
       "created_at": "2015-09-11T02:40:18.000Z",
-      "url": "https://preactjs.com",
-      "slug": "preact"
+      "url": "https://preactjs.com"
     },
     {
       "name": "umi",
+      "slug": "umi",
       "full_name": "umijs/umi",
       "description": "Pluggable enterprise-level react application framework.",
       "stars": 9799,
@@ -1424,11 +1431,11 @@
       "tags": ["nodejs-framework", "react"],
       "owner_id": 33895495,
       "created_at": "2017-11-22T10:09:36.000Z",
-      "url": "https://umijs.org",
-      "slug": "umi"
+      "url": "https://umijs.org"
     },
     {
       "name": "Twin",
+      "slug": "twin",
       "full_name": "ben-rogerson/twin.macro",
       "description": "Blends the magic of Tailwind with the flexibility of css-in-js",
       "stars": 2958,
@@ -1436,11 +1443,11 @@
       "monthly": [370, 0],
       "tags": ["css-in-js", "react"],
       "owner_id": 21288568,
-      "created_at": "2020-02-19T04:45:25.000Z",
-      "slug": "twin"
+      "created_at": "2020-02-19T04:45:25.000Z"
     },
     {
       "name": "Ionic",
+      "slug": "ionic",
       "full_name": "ionic-team/ionic-framework",
       "description": "A powerful cross-platform UI toolkit for building native-quality iOS, Android, and Progressive Web Apps with HTML, CSS, and JavaScript.",
       "stars": 42806,
@@ -1452,11 +1459,11 @@
       "owner_id": 3171503,
       "icon": "ionic.svg",
       "created_at": "2013-08-20T23:06:02.000Z",
-      "url": "https://ionicframework.com",
-      "slug": "ionic"
+      "url": "https://ionicframework.com"
     },
     {
       "name": "htmx",
+      "slug": "htmx",
       "full_name": "bigskysoftware/htmx",
       "description": "Access AJAX, WebSockets and Server Sent Events directly in HTML",
       "stars": 2756,
@@ -1466,11 +1473,11 @@
       "owner_id": 48798027,
       "icon": "htmx.svg",
       "created_at": "2020-04-13T16:17:51.000Z",
-      "url": "https://htmx.org",
-      "slug": "htmx"
+      "url": "https://htmx.org"
     },
     {
       "name": "Babel",
+      "slug": "babel",
       "full_name": "babel/babel",
       "description": "A compiler for writing next generation JavaScript.",
       "stars": 38178,
@@ -1482,11 +1489,11 @@
       "owner_id": 9637642,
       "icon": "babel.svg",
       "created_at": "2014-09-28T13:38:23.000Z",
-      "url": "https://babel.dev",
-      "slug": "babel"
+      "url": "https://babel.dev"
     },
     {
       "name": "ngx-admin",
+      "slug": "ngx-admin",
       "full_name": "akveo/ngx-admin",
       "description": "Customizable admin dashboard template based on Angular 10+",
       "stars": 21981,
@@ -1497,11 +1504,11 @@
       "tags": ["angular", "dashboard"],
       "owner_id": 11921694,
       "created_at": "2016-05-25T10:09:03.000Z",
-      "url": "https://akveo.github.io/ngx-admin/",
-      "slug": "ngx-admin"
+      "url": "https://akveo.github.io/ngx-admin/"
     },
     {
       "name": "Emotion",
+      "slug": "emotion",
       "full_name": "emotion-js/emotion",
       "description": "CSS-in-JS library designed for high performance style composition",
       "stars": 12292,
@@ -1512,11 +1519,11 @@
       "tags": ["css-in-js"],
       "owner_id": 31557565,
       "created_at": "2017-05-27T04:23:45.000Z",
-      "url": "https://emotion.sh/",
-      "slug": "emotion"
+      "url": "https://emotion.sh/"
     },
     {
       "name": "Jotai",
+      "slug": "jotai",
       "full_name": "pmndrs/jotai",
       "description": "Primitive, flexible state management for React",
       "stars": 2494,
@@ -1526,10 +1533,11 @@
       "owner_id": 45790596,
       "created_at": "2020-08-11T23:15:36.000Z",
       "url": "https://jotai.surge.sh",
-      "slug": "jotai"
+      "icon": "jotai.webp"
     },
     {
       "name": "Apollo client",
+      "slug": "apollo-client",
       "full_name": "apollographql/apollo-client",
       "description": "A fully-featured, production ready caching GraphQL client for every UI framework and GraphQL server",
       "stars": 15368,
@@ -1541,11 +1549,11 @@
       "owner_id": 17189275,
       "icon": "apollo.svg",
       "created_at": "2016-02-26T20:25:00.000Z",
-      "url": "https://apollographql.com/client",
-      "slug": "apollo-client"
+      "url": "https://apollographql.com/client"
     },
     {
       "name": "Webiny",
+      "slug": "webiny",
       "full_name": "webiny/webiny-js",
       "description": "Platform for building serverless applications and APIs (Node.js, React, GraphQL)",
       "stars": 4083,
@@ -1556,11 +1564,11 @@
       "tags": ["graphql", "cms", "serverless", "fullstack"],
       "owner_id": 3808429,
       "created_at": "2018-01-09T13:09:44.000Z",
-      "url": "https://www.webiny.com/",
-      "slug": "webiny"
+      "url": "https://www.webiny.com/"
     },
     {
       "name": "rrweb",
+      "slug": "rrweb",
       "full_name": "rrweb-io/rrweb",
       "description": "record and replay the web",
       "stars": 8199,
@@ -1571,11 +1579,11 @@
       "tags": ["debug", "auto"],
       "owner_id": 43396833,
       "created_at": "2018-10-06T13:35:55.000Z",
-      "url": "https://www.rrweb.io/",
-      "slug": "rrweb"
+      "url": "https://www.rrweb.io/"
     },
     {
       "name": "Koa",
+      "slug": "koa",
       "full_name": "koajs/koa",
       "description": "Expressive middleware for node.js using ES2017 async functions",
       "stars": 30532,
@@ -1586,11 +1594,11 @@
       "tags": ["nodejs-framework"],
       "owner_id": 5055057,
       "created_at": "2013-07-20T18:53:45.000Z",
-      "url": "https://koajs.com",
-      "slug": "koa"
+      "url": "https://koajs.com"
     },
     {
       "name": "GraphQL Code Generator",
+      "slug": "graphql-code-generator",
       "full_name": "dotansimha/graphql-code-generator",
       "description": "A tool for generating code based on a GraphQL schema and GraphQL operations (query/mutation/subscription), with flexible support for custom plugins.",
       "stars": 6096,
@@ -1602,10 +1610,11 @@
       "owner_id": 3680083,
       "created_at": "2016-12-05T19:15:11.000Z",
       "url": "https://graphql-code-generator.com",
-      "slug": "graphql-code-generator"
+      "icon": "graphql-code-generator.svg"
     },
     {
       "name": "Rollup",
+      "slug": "rollup",
       "full_name": "rollup/rollup",
       "description": "Next-generation ES module bundler",
       "stars": 19489,
@@ -1617,11 +1626,11 @@
       "owner_id": 12554859,
       "icon": "rollup.svg",
       "created_at": "2015-05-14T22:26:28.000Z",
-      "url": "https://rollupjs.org",
-      "slug": "rollup"
+      "url": "https://rollupjs.org"
     },
     {
       "name": "TypeGraphQL",
+      "slug": "typegraphql",
       "full_name": "MichalLytek/type-graphql",
       "description": "Create GraphQL schema and resolvers with TypeScript, using classes and decorators!",
       "stars": 5739,
@@ -1630,11 +1639,11 @@
       "tags": ["graphql", "nodejs-framework"],
       "owner_id": 10618781,
       "created_at": "2018-01-09T15:58:38.000Z",
-      "url": "https://typegraphql.com",
-      "slug": "typegraphql"
+      "url": "https://typegraphql.com"
     },
     {
       "name": "Mock Service Worker",
+      "slug": "mock-service-worker",
       "full_name": "mswjs/msw",
       "description": "Seamless REST/GraphQL API mocking library for browser and Node.",
       "stars": 4485,
@@ -1643,11 +1652,11 @@
       "tags": ["test", "serviceworker"],
       "owner_id": 64637271,
       "created_at": "2018-11-13T14:58:44.000Z",
-      "url": "https://mswjs.io",
-      "slug": "mock-service-worker"
+      "url": "https://mswjs.io"
     },
     {
       "name": "Halfmoon",
+      "slug": "halfmoon",
       "full_name": "halfmoonui/halfmoon",
       "description": "Front-end framework with a built-in dark mode and full customizability using CSS variables; great for building dashboards and tools.",
       "stars": 2085,
@@ -1657,11 +1666,11 @@
       "owner_id": 67643916,
       "icon": "halfmoon.svg",
       "created_at": "2020-06-30T19:26:01.000Z",
-      "url": "https://www.gethalfmoon.com",
-      "slug": "halfmoon"
+      "url": "https://www.gethalfmoon.com"
     },
     {
       "name": "Stimulus",
+      "slug": "stimulus",
       "full_name": "hotwired/stimulus",
       "description": "A modest JavaScript framework for the HTML you already have",
       "stars": 9935,
@@ -1671,11 +1680,11 @@
       "owner_id": 75388917,
       "icon": "stimulus.svg",
       "created_at": "2016-12-17T00:19:29.000Z",
-      "url": "https://stimulus.hotwire.dev/",
-      "slug": "stimulus"
+      "url": "https://stimulus.hotwire.dev/"
     },
     {
       "name": "Apollo Server",
+      "slug": "apollo-server",
       "full_name": "apollographql/apollo-server",
       "description": "GraphQL server for Express, Connect, Hapi, Koa and more",
       "stars": 10838,
@@ -1687,11 +1696,11 @@
       "owner_id": 17189275,
       "icon": "apollo.svg",
       "created_at": "2016-04-21T09:26:01.000Z",
-      "url": "https://www.apollographql.com/docs/apollo-server/",
-      "slug": "apollo-server"
+      "url": "https://www.apollographql.com/docs/apollo-server/"
     },
     {
       "name": "Gridsome",
+      "slug": "gridsome",
       "full_name": "gridsome/gridsome",
       "description": "️ The Jamstack framework for Vue.js",
       "stars": 7163,
@@ -1702,11 +1711,11 @@
       "tags": ["ssg", "vue", "graphql"],
       "owner_id": 17981963,
       "created_at": "2018-07-31T22:55:06.000Z",
-      "url": "https://gridsome.org",
-      "slug": "gridsome"
+      "url": "https://gridsome.org"
     },
     {
       "name": "Egg",
+      "slug": "egg",
       "full_name": "eggjs/egg",
       "description": "Born to build better enterprise frameworks and apps with Node.js & Koa",
       "stars": 16565,
@@ -1717,11 +1726,11 @@
       "tags": ["nodejs-framework"],
       "owner_id": 15833670,
       "created_at": "2016-06-18T06:53:23.000Z",
-      "url": "https://eggjs.org",
-      "slug": "egg"
+      "url": "https://eggjs.org"
     },
     {
       "name": "MobX",
+      "slug": "mobx",
       "full_name": "mobxjs/mobx",
       "description": "Simple, scalable state management.",
       "stars": 23037,
@@ -1733,11 +1742,11 @@
       "owner_id": 17475736,
       "icon": "mobx.svg",
       "created_at": "2015-03-14T14:31:38.000Z",
-      "url": "http://mobx.js.org",
-      "slug": "mobx"
+      "url": "http://mobx.js.org"
     },
     {
       "name": "Keystone",
+      "slug": "keystone",
       "full_name": "keystonejs/keystone",
       "description": "The most powerful headless CMS for Node.js — built with GraphQL and React",
       "stars": 3126,
@@ -1749,11 +1758,11 @@
       "owner_id": 6118534,
       "icon": "keystone.svg",
       "created_at": "2018-04-05T10:48:37.000Z",
-      "url": "https://www.keystonejs.com/",
-      "slug": "keystone"
+      "url": "https://www.keystonejs.com/"
     },
     {
       "name": "Linaria",
+      "slug": "linaria",
       "full_name": "callstack/linaria",
       "description": "Zero-runtime CSS in JS library",
       "stars": 6552,
@@ -1765,11 +1774,11 @@
       "owner_id": 42239399,
       "icon": "linaria.svg",
       "created_at": "2017-05-23T00:52:34.000Z",
-      "url": "https://linaria.dev",
-      "slug": "linaria"
+      "url": "https://linaria.dev"
     },
     {
       "name": "Theme UI",
+      "slug": "theme-ui",
       "full_name": "system-ui/theme-ui",
       "description": "Build consistent, themeable React apps based on constraint-based design principles",
       "stars": 3339,
@@ -1778,8 +1787,7 @@
       "tags": ["css-in-js"],
       "owner_id": 48816045,
       "created_at": "2019-04-03T22:10:49.000Z",
-      "url": "https://theme-ui.com",
-      "slug": "theme-ui"
+      "url": "https://theme-ui.com"
     },
     {
       "name": "Sonar",
@@ -1798,6 +1806,7 @@
     },
     {
       "name": "jsdom",
+      "slug": "jsdom",
       "full_name": "jsdom/jsdom",
       "description": "A JavaScript implementation of various web standards, for use with Node.js",
       "stars": 15219,
@@ -1808,11 +1817,11 @@
       "tags": ["test"],
       "owner_id": 9271229,
       "icon": "jsdom.svg",
-      "created_at": "2010-01-19T06:55:19.000Z",
-      "slug": "jsdom"
+      "created_at": "2010-01-19T06:55:19.000Z"
     },
     {
       "name": "SemanticUI",
+      "slug": "semanticui",
       "full_name": "Semantic-Org/Semantic-UI",
       "description": "Semantic is a UI component framework based around useful principles from natural language.",
       "stars": 48894,
@@ -1824,11 +1833,11 @@
       "owner_id": 5796209,
       "icon": "semantic-ui.svg",
       "created_at": "2013-04-08T23:32:04.000Z",
-      "url": "http://www.semantic-ui.com",
-      "slug": "semanticui"
+      "url": "http://www.semantic-ui.com"
     },
     {
       "name": "Adonis",
+      "slug": "adonis",
       "full_name": "adonisjs/core",
       "description": "The Node.js Framework highly focused on developer ergonomics, stability and confidence",
       "stars": 9294,
@@ -1839,11 +1848,11 @@
       "tags": ["nodejs-framework"],
       "owner_id": 13810373,
       "created_at": "2015-08-15T17:03:54.000Z",
-      "url": "https://preview.adonisjs.com",
-      "slug": "adonis"
+      "url": "https://preview.adonisjs.com"
     },
     {
       "name": "Crank.js",
+      "slug": "crankjs",
       "full_name": "bikeshaving/crank",
       "description": "Write JSX-driven components with functions, promises and generators.",
       "stars": 2261,
@@ -1852,11 +1861,11 @@
       "tags": ["framework"],
       "owner_id": 51215678,
       "created_at": "2019-09-05T00:27:50.000Z",
-      "url": "https://crank.js.org",
-      "slug": "crankjs"
+      "url": "https://crank.js.org"
     },
     {
       "name": "Stencil",
+      "slug": "stencil",
       "full_name": "ionic-team/stencil",
       "description": "A Web Component compiler for building fast, reusable UI components and static site generated Progressive Web Apps",
       "stars": 8753,
@@ -1868,11 +1877,11 @@
       "owner_id": 3171503,
       "icon": "stencil.svg",
       "created_at": "2017-02-15T18:57:07.000Z",
-      "url": "https://stenciljs.com",
-      "slug": "stencil"
+      "url": "https://stenciljs.com"
     },
     {
       "name": "Stitches",
+      "slug": "stitches",
       "full_name": "modulz/stitches",
       "description": "The modern styling library.",
       "stars": 1641,
@@ -1882,11 +1891,11 @@
       "owner_id": 28682402,
       "icon": "stitches.svg",
       "created_at": "2020-04-14T07:07:35.000Z",
-      "url": "https://stitches.dev",
-      "slug": "stitches"
+      "url": "https://stitches.dev"
     },
     {
       "name": "Material Design for Angular",
+      "slug": "material-design-for-angular",
       "full_name": "angular/components",
       "description": "Component infrastructure and Material Design components for Angular",
       "stars": 20794,
@@ -1897,11 +1906,11 @@
       "tags": ["material", "angular", "component"],
       "owner_id": 139426,
       "created_at": "2016-01-04T18:50:02.000Z",
-      "url": "https://material.angular.io",
-      "slug": "material-design-for-angular"
+      "url": "https://material.angular.io"
     },
     {
       "name": "NativeScript",
+      "slug": "nativescript",
       "full_name": "NativeScript/NativeScript",
       "description": "NativeScript empowers you to access native api's from JavaScript directly. Angular, Vue, Svelte, React and you name it compatible.",
       "stars": 19596,
@@ -1913,11 +1922,11 @@
       "owner_id": 7392261,
       "icon": "nativescript.svg",
       "created_at": "2015-03-01T09:47:08.000Z",
-      "url": "https://www.nativescript.org",
-      "slug": "nativescript"
+      "url": "https://www.nativescript.org"
     },
     {
       "name": "Material Components",
+      "slug": "material-components",
       "full_name": "material-components/material-components-web",
       "description": "Modular and customizable Material Design UI components for the web",
       "stars": 15180,
@@ -1928,11 +1937,11 @@
       "tags": ["material", "css-lib"],
       "owner_id": 19478152,
       "created_at": "2016-12-05T16:04:09.000Z",
-      "url": "https://material.io/develop/web",
-      "slug": "material-components"
+      "url": "https://material.io/develop/web"
     },
     {
       "name": "CSS Modules",
+      "slug": "css-modules",
       "full_name": "css-modules/css-modules",
       "description": "Documentation about css-modules",
       "stars": 14522,
@@ -1942,11 +1951,11 @@
       ],
       "tags": ["css-in-js"],
       "owner_id": 12612655,
-      "created_at": "2015-05-25T21:54:47.000Z",
-      "slug": "css-modules"
+      "created_at": "2015-05-25T21:54:47.000Z"
     },
     {
       "name": "Valtio",
+      "slug": "valtio",
       "full_name": "pmndrs/valtio",
       "description": "Proxy-state simple for React and Vanilla ",
       "stars": 1537,
@@ -1954,11 +1963,11 @@
       "monthly": [283, 1083],
       "tags": ["state", "react"],
       "owner_id": 45790596,
-      "created_at": "2020-11-16T22:30:51.000Z",
-      "slug": "valtio"
+      "created_at": "2020-11-16T22:30:51.000Z"
     },
     {
       "name": "Scully",
+      "slug": "scully",
       "full_name": "scullyio/scully",
       "description": "The Static Site Generator for Angular apps",
       "stars": 1964,
@@ -1967,11 +1976,11 @@
       "tags": ["ssg", "angular"],
       "owner_id": 58822549,
       "created_at": "2019-12-12T16:51:23.000Z",
-      "url": "https://scully.io/",
-      "slug": "scully"
+      "url": "https://scully.io/"
     },
     {
       "name": "Gun",
+      "slug": "gun",
       "full_name": "amark/gun",
       "description": "An open source cybersecurity protocol for syncing decentralized graph data.",
       "stars": 12434,
@@ -1983,11 +1992,11 @@
       "owner_id": 433412,
       "icon": "gun.svg",
       "created_at": "2014-07-31T15:52:10.000Z",
-      "url": "https://gun.eco/docs",
-      "slug": "gun"
+      "url": "https://gun.eco/docs"
     },
     {
       "name": "Microbundle",
+      "slug": "microbundle",
       "full_name": "developit/microbundle",
       "description": "Zero-configuration bundler for tiny modules.",
       "stars": 5608,
@@ -1997,11 +2006,11 @@
       ],
       "tags": ["module", "build"],
       "owner_id": 105127,
-      "created_at": "2017-12-11T21:51:02.000Z",
-      "slug": "microbundle"
+      "created_at": "2017-12-11T21:51:02.000Z"
     },
     {
       "name": "Capacitor",
+      "slug": "capacitor",
       "full_name": "ionic-team/capacitor",
       "description": "Build cross-platform Native Progressive Web Apps for iOS, Android, and the Web ️",
       "stars": 4923,
@@ -2010,11 +2019,11 @@
       "tags": ["mobile"],
       "owner_id": 3171503,
       "created_at": "2017-11-18T21:38:09.000Z",
-      "url": "https://capacitorjs.com",
-      "slug": "capacitor"
+      "url": "https://capacitorjs.com"
     },
     {
       "name": "NativeBase",
+      "slug": "nativebase",
       "full_name": "GeekyAnts/NativeBase",
       "description": "Essential cross-platform UI components for React Native",
       "stars": 14600,
@@ -2026,10 +2035,11 @@
       "owner_id": 18482943,
       "created_at": "2016-04-15T11:37:23.000Z",
       "url": "https://nativebase.io/",
-      "slug": "nativebase"
+      "icon": "nativebase.svg"
     },
     {
       "name": "Materialize CSS",
+      "slug": "materialize-css",
       "full_name": "Dogfalo/materialize",
       "description": "Materialize, a CSS Framework based on Material Design",
       "stars": 38291,
@@ -2039,11 +2049,11 @@
       "owner_id": 2775751,
       "icon": "materializecss.svg",
       "created_at": "2014-09-12T19:35:38.000Z",
-      "url": "https://materializecss.com",
-      "slug": "materialize-css"
+      "url": "https://materializecss.com"
     },
     {
       "name": "Unstated Next",
+      "slug": "unstated-next",
       "full_name": "jamiebuilds/unstated-next",
       "description": "200 bytes to never think about React state management libraries ever again",
       "stars": 3157,
@@ -2051,11 +2061,11 @@
       "monthly": [64, 67, 85, 78, 94, 87, 124, 161, 136, 132, 114, 95, 145],
       "tags": ["react", "state"],
       "owner_id": 952783,
-      "created_at": "2019-05-02T00:44:35.000Z",
-      "slug": "unstated-next"
+      "created_at": "2019-05-02T00:44:35.000Z"
     },
     {
       "name": "UIkit",
+      "slug": "uikit",
       "full_name": "uikit/uikit",
       "description": "A lightweight and modular front-end framework for developing fast and powerful web interfaces",
       "stars": 16560,
@@ -2065,11 +2075,11 @@
       "owner_id": 4173184,
       "icon": "uikit.svg",
       "created_at": "2013-07-18T16:00:26.000Z",
-      "url": "http://getuikit.com",
-      "slug": "uikit"
+      "url": "http://getuikit.com"
     },
     {
       "name": "Angular CLI",
+      "slug": "angular-cli",
       "full_name": "angular/angular-cli",
       "description": "CLI tool for Angular",
       "stars": 24084,
@@ -2080,11 +2090,11 @@
       "tags": ["angular", "scaffolding"],
       "owner_id": 139426,
       "created_at": "2015-06-04T19:49:37.000Z",
-      "url": "https://cli.angular.io",
-      "slug": "angular-cli"
+      "url": "https://cli.angular.io"
     },
     {
       "name": "Relay",
+      "slug": "relay",
       "full_name": "facebook/relay",
       "description": "Relay is a JavaScript framework for building data-driven React applications.",
       "stars": 15244,
@@ -2094,11 +2104,11 @@
       "owner_id": 69631,
       "icon": "relay.svg",
       "created_at": "2015-08-10T22:09:16.000Z",
-      "url": "https://relay.dev",
-      "slug": "relay"
+      "url": "https://relay.dev"
     },
     {
       "name": "NG-ZORRO",
+      "slug": "ng-zorro",
       "full_name": "NG-ZORRO/ng-zorro-antd",
       "description": "Angular UI Component Library based on Ant Design",
       "stars": 7191,
@@ -2107,11 +2117,11 @@
       "tags": ["angular", "component"],
       "owner_id": 30223759,
       "created_at": "2017-08-08T14:59:33.000Z",
-      "url": "https://ng.ant.design",
-      "slug": "ng-zorro"
+      "url": "https://ng.ant.design"
     },
     {
       "name": "Moon",
+      "slug": "moon",
       "full_name": "kbrsh/moon",
       "description": "The minimal & fast library for functional user interfaces",
       "stars": 6032,
@@ -2121,11 +2131,11 @@
       "owner_id": 15644571,
       "icon": "moon.svg",
       "created_at": "2016-07-14T04:53:09.000Z",
-      "url": "https://moonjs.org",
-      "slug": "moon"
+      "url": "https://moonjs.org"
     },
     {
       "name": "Hyperapp",
+      "slug": "hyperapp",
       "full_name": "jorgebucaran/hyperapp",
       "description": "The tiny framework for building hypertext applications.",
       "stars": 18251,
@@ -2134,11 +2144,11 @@
       "tags": ["framework", "state"],
       "owner_id": 56996,
       "icon": "hyperapp.svg",
-      "created_at": "2017-01-20T05:20:21.000Z",
-      "slug": "hyperapp"
+      "created_at": "2017-01-20T05:20:21.000Z"
     },
     {
       "name": "styled-system",
+      "slug": "styled-system",
       "full_name": "styled-system/styled-system",
       "description": "Style props for rapid UI development",
       "stars": 6428,
@@ -2147,11 +2157,11 @@
       "tags": ["css-in-js"],
       "owner_id": 47362392,
       "created_at": "2017-06-14T23:21:17.000Z",
-      "url": "https://styled-system.com",
-      "slug": "styled-system"
+      "url": "https://styled-system.com"
     },
     {
       "name": "Rax",
+      "slug": "rax",
       "full_name": "alibaba/rax",
       "description": "The fastest way to build universal application",
       "stars": 7006,
@@ -2160,11 +2170,11 @@
       "tags": ["vdom", "framework"],
       "owner_id": 1961952,
       "icon": "rax.svg",
-      "created_at": "2016-10-14T07:53:50.000Z",
-      "slug": "rax"
+      "created_at": "2016-10-14T07:53:50.000Z"
     },
     {
       "name": "dva",
+      "slug": "dva",
       "full_name": "dvajs/dva",
       "description": "React and redux based, lightweight and elm-style framework. (Inspired by elm and choo)",
       "stars": 15390,
@@ -2173,11 +2183,11 @@
       "tags": ["framework", "redux"],
       "owner_id": 20552239,
       "created_at": "2016-06-24T09:06:16.000Z",
-      "url": "https://dvajs.com/",
-      "slug": "dva"
+      "url": "https://dvajs.com/"
     },
     {
       "name": "Feathers",
+      "slug": "feathers",
       "full_name": "feathersjs/feathers",
       "description": "A framework for real-time applications and REST APIs with JavaScript and TypeScript",
       "stars": 13100,
@@ -2187,11 +2197,11 @@
       "owner_id": 5321853,
       "icon": "feathers.svg",
       "created_at": "2011-10-19T22:45:16.000Z",
-      "url": "https://feathersjs.com",
-      "slug": "feathers"
+      "url": "https://feathersjs.com"
     },
     {
       "name": "Primer",
+      "slug": "primer",
       "full_name": "primer/css",
       "description": "The CSS design system that powers GitHub",
       "stars": 9896,
@@ -2200,11 +2210,11 @@
       "tags": ["css-lib"],
       "owner_id": 7143434,
       "created_at": "2015-03-19T23:31:21.000Z",
-      "url": "https://primer.style/css",
-      "slug": "primer"
+      "url": "https://primer.style/css"
     },
     {
       "name": "Omi",
+      "slug": "omi",
       "full_name": "Tencent/omi",
       "description": "Next Front End Framework",
       "stars": 11625,
@@ -2214,11 +2224,11 @@
       "owner_id": 18461506,
       "icon": "omi.svg",
       "created_at": "2015-05-31T14:24:58.000Z",
-      "url": "http://omijs.org",
-      "slug": "omi"
+      "url": "http://omijs.org"
     },
     {
       "name": "NgRx",
+      "slug": "ngrx",
       "full_name": "ngrx/platform",
       "description": "Reactive libraries for Angular",
       "stars": 6583,
@@ -2227,11 +2237,11 @@
       "tags": ["angular", "reactive", "state"],
       "owner_id": 16272733,
       "created_at": "2017-03-02T19:34:15.000Z",
-      "url": "https://ngrx.io",
-      "slug": "ngrx"
+      "url": "https://ngrx.io"
     },
     {
       "name": "Hapi",
+      "slug": "hapi",
       "full_name": "hapijs/hapi",
       "description": "The Simple, Secure Framework Developers Trust",
       "stars": 12986,
@@ -2241,11 +2251,11 @@
       "owner_id": 3774533,
       "icon": "hapi.svg",
       "created_at": "2011-08-06T00:35:39.000Z",
-      "url": "https://hapi.dev",
-      "slug": "hapi"
+      "url": "https://hapi.dev"
     },
     {
       "name": "Nebular",
+      "slug": "nebular",
       "full_name": "akveo/nebular",
       "description": "Customizable Angular UI Library based on Eva Design System Dark Mode",
       "stars": 6746,
@@ -2254,11 +2264,11 @@
       "tags": ["angular", "component"],
       "owner_id": 11921694,
       "created_at": "2017-09-20T08:33:06.000Z",
-      "url": "https://akveo.github.io/nebular",
-      "slug": "nebular"
+      "url": "https://akveo.github.io/nebular"
     },
     {
       "name": "tinyhttp",
+      "slug": "tinyhttp",
       "full_name": "talentlessguy/tinyhttp",
       "description": "Modern Express-like web framework",
       "stars": 1018,
@@ -2267,11 +2277,11 @@
       "tags": ["nodejs-framework", "express"],
       "owner_id": 35937217,
       "created_at": "2020-06-13T01:19:08.000Z",
-      "url": "https://tinyhttp.v1rtl.site",
-      "slug": "tinyhttp"
+      "url": "https://tinyhttp.v1rtl.site"
     },
     {
       "name": "Angular Electron",
+      "slug": "angular-electron",
       "full_name": "maximegris/angular-electron",
       "description": "Ultra-fast bootstrapping with Angular and Electron (Typescript + SASS + Hot Reload)",
       "stars": 4328,
@@ -2279,11 +2289,11 @@
       "monthly": [71, 68, 59, 76, 54, 87, 105, 123, 101, 97, 87, 44],
       "tags": ["desktop", "angular"],
       "owner_id": 10827551,
-      "created_at": "2017-04-02T11:15:28.000Z",
-      "slug": "angular-electron"
+      "created_at": "2017-04-02T11:15:28.000Z"
     },
     {
       "name": "cube-ui",
+      "slug": "cube-ui",
       "full_name": "didi/cube-ui",
       "description": "A fantastic mobile ui lib implement by Vue",
       "stars": 8586,
@@ -2292,11 +2302,11 @@
       "tags": ["vue", "mobile"],
       "owner_id": 27521938,
       "created_at": "2017-11-03T06:17:27.000Z",
-      "url": "https://didi.github.io/cube-ui/",
-      "slug": "cube-ui"
+      "url": "https://didi.github.io/cube-ui/"
     },
     {
       "name": "Polka",
+      "slug": "polka",
       "full_name": "lukeed/polka",
       "description": "A micro web server so fast, it'll make you dance!",
       "stars": 4492,
@@ -2304,11 +2314,11 @@
       "monthly": [73, 55, 41, 121, 50, 70, 77, 58, 89, 125, 62, 102, 31, 4],
       "tags": ["nodejs-framework"],
       "owner_id": 5855893,
-      "created_at": "2017-12-22T05:55:41.000Z",
-      "slug": "polka"
+      "created_at": "2017-12-22T05:55:41.000Z"
     },
     {
       "name": "Neo.mjs",
+      "slug": "neomjs",
       "full_name": "neomjs/neo",
       "description": "The webworkers driven UI framework",
       "stars": 1182,
@@ -2317,11 +2327,11 @@
       "tags": ["framework", "webworker"],
       "owner_id": 55371235,
       "created_at": "2019-11-10T23:56:02.000Z",
-      "url": "https://neomjs.github.io/pages/",
-      "slug": "neomjs"
+      "url": "https://neomjs.github.io/pages/"
     },
     {
       "name": "ag-grid",
+      "slug": "ag-grid",
       "full_name": "ag-grid/ag-grid",
       "description": "Advanced Data Grid / Data Table supporting Javascript / React / AngularJS / Web Components",
       "stars": 6811,
@@ -2330,11 +2340,11 @@
       "tags": ["table", "react", "angular"],
       "owner_id": 30720768,
       "created_at": "2014-12-23T16:20:14.000Z",
-      "url": "http://www.ag-grid.com",
-      "slug": "ag-grid"
+      "url": "http://www.ag-grid.com"
     },
     {
       "name": "Styled JSX",
+      "slug": "styled-jsx",
       "full_name": "vercel/styled-jsx",
       "description": "Full CSS support for JSX without compromises",
       "stars": 5977,
@@ -2342,11 +2352,11 @@
       "monthly": [56, 75, 68, 60, 47, 63, 72, 77, 92, 94, 81, 74, 84, 4],
       "tags": ["css-in-js"],
       "owner_id": 14985020,
-      "created_at": "2016-12-05T13:58:02.000Z",
-      "slug": "styled-jsx"
+      "created_at": "2016-12-05T13:58:02.000Z"
     },
     {
       "name": "Polished",
+      "slug": "polished",
       "full_name": "styled-components/polished",
       "description": "A lightweight toolset for writing styles in JavaScript",
       "stars": 6565,
@@ -2355,11 +2365,11 @@
       "tags": ["css-in-js"],
       "owner_id": 20658825,
       "created_at": "2016-11-03T14:39:21.000Z",
-      "url": "https://polished.js.org/",
-      "slug": "polished"
+      "url": "https://polished.js.org/"
     },
     {
       "name": "LoopBack 4",
+      "slug": "loopback-4",
       "full_name": "strongloop/loopback-next",
       "description": "A highly extensible Node.js and TypeScript framework\r\nfor building APIs and microservices",
       "stars": 3330,
@@ -2369,11 +2379,11 @@
       "owner_id": 3020012,
       "icon": "loopback.svg",
       "created_at": "2017-01-09T17:27:14.000Z",
-      "url": "https://loopback.io/",
-      "slug": "loopback-4"
+      "url": "https://loopback.io/"
     },
     {
       "name": "Framework7",
+      "slug": "framework7",
       "full_name": "framework7io/framework7",
       "description": "Full featured HTML framework for building iOS & Android apps",
       "stars": 15938,
@@ -2382,11 +2392,11 @@
       "tags": ["mobile"],
       "owner_id": 31954178,
       "created_at": "2014-02-23T12:15:53.000Z",
-      "url": "http://framework7.io",
-      "slug": "framework7"
+      "url": "http://framework7.io"
     },
     {
       "name": "Angular Fire",
+      "slug": "angular-fire",
       "full_name": "angular/angularfire",
       "description": "The official Angular library for Firebase.",
       "stars": 6531,
@@ -2395,11 +2405,11 @@
       "tags": ["angular"],
       "owner_id": 139426,
       "created_at": "2016-01-11T20:47:23.000Z",
-      "url": "https://firebaseopensource.com/projects/angular/angularfire2",
-      "slug": "angular-fire"
+      "url": "https://firebaseopensource.com/projects/angular/angularfire2"
     },
     {
       "name": "Reason",
+      "slug": "reason",
       "full_name": "reasonml/reason",
       "description": "Simple, fast & type safe code that leverages the JavaScript & OCaml ecosystems",
       "stars": 9200,
@@ -2409,11 +2419,11 @@
       "owner_id": 20414525,
       "icon": "reason.svg",
       "created_at": "2015-11-16T08:22:32.000Z",
-      "url": "http://reasonml.github.io",
-      "slug": "reason"
+      "url": "http://reasonml.github.io"
     },
     {
       "name": "Flow",
+      "slug": "flow",
       "full_name": "facebook/flow",
       "description": "Adds static typing to JavaScript to improve developer productivity and code quality.",
       "stars": 21116,
@@ -2423,11 +2433,11 @@
       "owner_id": 69631,
       "icon": "flow.svg",
       "created_at": "2014-10-28T17:17:45.000Z",
-      "url": "https://flow.org/",
-      "slug": "flow"
+      "url": "https://flow.org/"
     },
     {
       "name": "Sucrase",
+      "slug": "sucrase",
       "full_name": "alangpierce/sucrase",
       "description": "Super-fast alternative to Babel for when you can target modern JS runtimes",
       "stars": 2924,
@@ -2436,11 +2446,11 @@
       "tags": ["compiler", "code-parser"],
       "owner_id": 211605,
       "created_at": "2017-10-03T16:54:00.000Z",
-      "url": "https://sucrase.io",
-      "slug": "sucrase"
+      "url": "https://sucrase.io"
     },
     {
       "name": "Vidact",
+      "slug": "vidact",
       "full_name": "mohebifar/vidact",
       "description": "A compiler that converts React-compatible codes to VanillaJS with no Virtual DOM",
       "stars": 676,
@@ -2449,11 +2459,11 @@
       "tags": ["framework"],
       "owner_id": 6104558,
       "created_at": "2020-03-07T06:19:40.000Z",
-      "url": "https://mohebifar.github.io/vidact/",
-      "slug": "vidact"
+      "url": "https://mohebifar.github.io/vidact/"
     },
     {
       "name": "PureScript",
+      "slug": "purescript",
       "full_name": "purescript/purescript",
       "description": "A strongly-typed language that compiles to JavaScript",
       "stars": 6868,
@@ -2462,11 +2472,11 @@
       "tags": ["compiler", "types"],
       "owner_id": 6556677,
       "created_at": "2013-09-30T05:29:23.000Z",
-      "url": "https://www.purescript.org",
-      "slug": "purescript"
+      "url": "https://www.purescript.org"
     },
     {
       "name": "Elm",
+      "slug": "elm",
       "full_name": "elm/compiler",
       "description": "Compiler for Elm, a functional language for reliable webapps.",
       "stars": 6261,
@@ -2476,11 +2486,11 @@
       "owner_id": 20698192,
       "icon": "elm.svg",
       "created_at": "2012-04-19T06:24:43.000Z",
-      "url": "https://elm-lang.org/",
-      "slug": "elm"
+      "url": "https://elm-lang.org/"
     },
     {
       "name": "Reframe",
+      "slug": "reframe",
       "full_name": "day8/re-frame",
       "description": "A ClojureScript framework for building user interfaces, leveraging React",
       "stars": 4659,
@@ -2489,8 +2499,7 @@
       "tags": ["compiler"],
       "owner_id": 3033386,
       "created_at": "2014-12-05T11:08:39.000Z",
-      "url": "http://day8.github.io/re-frame/",
-      "slug": "reframe"
+      "url": "http://day8.github.io/re-frame/"
     }
   ],
   "tags": [

--- a/data/2021/projects.json
+++ b/data/2021/projects.json
@@ -2,6 +2,7 @@
   "projects": [
     {
       "name": "zx",
+      "slug": "zx",
       "full_name": "google/zx",
       "description": "A tool for writing better scripts",
       "stars": 24975,
@@ -23,10 +24,11 @@
       "tags": ["cli"],
       "owner_id": 1342004,
       "created_at": "2021-05-05T05:50:01.000Z",
-      "slug": "zx"
+      "icon": "zx.svg"
     },
     {
       "name": "Vite",
+      "slug": "vite",
       "full_name": "vitejs/vite",
       "description": "Next generation frontend tooling. It's fast!",
       "stars": 35794,
@@ -38,11 +40,11 @@
       "owner_id": 65625612,
       "icon": "vite.svg",
       "created_at": "2020-04-21T05:03:57.000Z",
-      "url": "http://vitejs.dev",
-      "slug": "vite"
+      "url": "http://vitejs.dev"
     },
     {
       "name": "Next.js",
+      "slug": "nextjs",
       "full_name": "vercel/next.js",
       "description": "The React Framework",
       "stars": 79233,
@@ -61,11 +63,11 @@
       "owner_id": 14985020,
       "icon": "nextjs.svg",
       "created_at": "2016-10-05T23:32:51.000Z",
-      "url": "https://nextjs.org",
-      "slug": "nextjs"
+      "url": "https://nextjs.org"
     },
     {
       "name": "React",
+      "slug": "react",
       "full_name": "facebook/react",
       "description": "A declarative, efficient, and flexible JavaScript library for building user interfaces.",
       "stars": 180325,
@@ -77,11 +79,11 @@
       "owner_id": 69631,
       "icon": "react.svg",
       "created_at": "2013-05-24T16:15:54.000Z",
-      "url": "https://reactjs.org",
-      "slug": "react"
+      "url": "https://reactjs.org"
     },
     {
       "name": "Tauri",
+      "slug": "tauri",
       "full_name": "tauri-apps/tauri",
       "description": "Build smaller, faster, and more secure desktop applications with a web frontend.",
       "stars": 26716,
@@ -93,11 +95,11 @@
       "owner_id": 54536011,
       "icon": "tauri.svg",
       "created_at": "2019-07-13T09:09:37.000Z",
-      "url": "https://tauri.studio",
-      "slug": "tauri"
+      "url": "https://tauri.studio"
     },
     {
       "name": "Tailwind CSS",
+      "slug": "tailwind-css",
       "full_name": "tailwindlabs/tailwindcss",
       "description": "A utility-first CSS framework for rapid UI development.",
       "stars": 51944,
@@ -109,11 +111,11 @@
       "owner_id": 67109815,
       "icon": "tailwindcss.svg",
       "created_at": "2017-10-06T14:59:14.000Z",
-      "url": "https://tailwindcss.com/",
-      "slug": "tailwind-css"
+      "url": "https://tailwindcss.com/"
     },
     {
       "name": "VS Code",
+      "slug": "vs-code",
       "full_name": "microsoft/vscode",
       "description": "Visual Studio Code",
       "stars": 126106,
@@ -125,11 +127,11 @@
       "owner_id": 6154722,
       "icon": "vscode.svg",
       "created_at": "2015-09-03T20:23:38.000Z",
-      "url": "https://code.visualstudio.com",
-      "slug": "vs-code"
+      "url": "https://code.visualstudio.com"
     },
     {
       "name": "Slidev",
+      "slug": "slidev",
       "full_name": "slidevjs/slidev",
       "description": "Presentation Slides for Developers (Beta)",
       "stars": 17154,
@@ -152,11 +154,11 @@
       "owner_id": 83095831,
       "icon": "slidev.svg",
       "created_at": "2021-04-24T01:25:23.000Z",
-      "url": "https://sli.dev",
-      "slug": "slidev"
+      "url": "https://sli.dev"
     },
     {
       "name": "NocoDB",
+      "slug": "nocodb",
       "full_name": "nocodb/nocodb",
       "description": "Open Source Airtable Alternative",
       "stars": 21110,
@@ -179,10 +181,11 @@
       "owner_id": 50206778,
       "created_at": "2017-10-29T18:51:48.000Z",
       "url": "https://docs.nocodb.com",
-      "slug": "nocodb"
+      "icon": "nocodb.svg"
     },
     {
       "name": "Vue.js",
+      "slug": "vuejs-2",
       "full_name": "vuejs/vue",
       "description": "A progressive, incrementally-adoptable framework for building UI on the web",
       "stars": 192022,
@@ -194,12 +197,11 @@
       "owner_id": 6128107,
       "icon": "vue.svg",
       "created_at": "2013-07-29T03:24:51.000Z",
-      "url": "http://vuejs.org",
-      "slug": "vuejs-2",
-      "ref": "vuejs"
+      "url": "http://vuejs.org"
     },
     {
       "name": "Svelte",
+      "slug": "svelte",
       "full_name": "sveltejs/svelte",
       "description": "Cybernetically enhanced web apps",
       "stars": 54528,
@@ -211,11 +213,11 @@
       "owner_id": 23617963,
       "icon": "svelte.svg",
       "created_at": "2016-11-20T18:13:05.000Z",
-      "url": "https://svelte.dev",
-      "slug": "svelte"
+      "url": "https://svelte.dev"
     },
     {
       "name": "esbuild",
+      "slug": "esbuild",
       "full_name": "evanw/esbuild",
       "description": "An extremely fast JavaScript and CSS bundler and minifier",
       "stars": 29755,
@@ -227,11 +229,11 @@
       "owner_id": 406394,
       "icon": "esbuild.svg",
       "created_at": "2016-06-14T16:08:50.000Z",
-      "url": "https://esbuild.github.io/",
-      "slug": "esbuild"
+      "url": "https://esbuild.github.io/"
     },
     {
       "name": "Prisma",
+      "slug": "prisma",
       "full_name": "prisma/prisma",
       "description": "Next-generation ORM for Node.js & TypeScript | PostgreSQL, MySQL, MariaDB, SQL Server, SQLite & MongoDB (Preview)",
       "stars": 19377,
@@ -243,11 +245,11 @@
       "owner_id": 17219288,
       "icon": "prisma.svg",
       "created_at": "2019-06-20T13:33:47.000Z",
-      "url": "https://www.prisma.io",
-      "slug": "prisma"
+      "url": "https://www.prisma.io"
     },
     {
       "name": "Playwright",
+      "slug": "playwright",
       "full_name": "microsoft/playwright",
       "description": "Playwright is a framework for Web Testing and Automation. It allows testing Chromium, Firefox and WebKit with a single API.",
       "stars": 31978,
@@ -259,11 +261,11 @@
       "owner_id": 6154722,
       "icon": "playwright.svg",
       "created_at": "2019-11-15T18:32:42.000Z",
-      "url": "https://playwright.dev",
-      "slug": "playwright"
+      "url": "https://playwright.dev"
     },
     {
       "name": "Three.js",
+      "slug": "threejs",
       "full_name": "mrdoob/three.js",
       "description": "JavaScript 3D Library.",
       "stars": 77557,
@@ -275,11 +277,11 @@
       "owner_id": 97088,
       "icon": "threejs.svg",
       "created_at": "2010-03-23T18:58:01.000Z",
-      "url": "https://threejs.org/",
-      "slug": "threejs"
+      "url": "https://threejs.org/"
     },
     {
       "name": "Electron",
+      "slug": "electron",
       "full_name": "electron/electron",
       "description": "Build cross-platform desktop apps with JavaScript, HTML, and CSS",
       "stars": 99638,
@@ -291,11 +293,11 @@
       "owner_id": 13409222,
       "icon": "electron.svg",
       "created_at": "2013-04-12T01:47:36.000Z",
-      "url": "https://electronjs.org",
-      "slug": "electron"
+      "url": "https://electronjs.org"
     },
     {
       "name": "Storybook",
+      "slug": "storybook",
       "full_name": "storybookjs/storybook",
       "description": "The UI component explorer. Develop, document, & test React, Vue, Angular, Web Components, Ember, Svelte & more!",
       "stars": 67895,
@@ -307,11 +309,11 @@
       "owner_id": 22632046,
       "icon": "storybook.svg",
       "created_at": "2016-03-18T04:23:44.000Z",
-      "url": "https://storybook.js.org",
-      "slug": "storybook"
+      "url": "https://storybook.js.org"
     },
     {
       "name": "Ant Design",
+      "slug": "ant-design",
       "full_name": "ant-design/ant-design",
       "description": "An enterprise-class UI design language and React UI library",
       "stars": 76887,
@@ -321,11 +323,11 @@
       "owner_id": 12101536,
       "icon": "ant.svg",
       "created_at": "2015-04-24T15:37:24.000Z",
-      "url": "https://ant.design",
-      "slug": "ant-design"
+      "url": "https://ant.design"
     },
     {
       "name": "Nest",
+      "slug": "nest",
       "full_name": "nestjs/nest",
       "description": "A progressive Node.js framework for building efficient, scalable, and enterprise-grade server-side applications on top of TypeScript & JavaScript (ES6, ES7, ES8)",
       "stars": 43442,
@@ -335,11 +337,11 @@
       "owner_id": 28507035,
       "icon": "nest.svg",
       "created_at": "2017-02-04T20:12:52.000Z",
-      "url": "https://nestjs.com",
-      "slug": "nest"
+      "url": "https://nestjs.com"
     },
     {
       "name": "Material UI",
+      "slug": "material-ui",
       "full_name": "mui-org/material-ui",
       "description": "A robust, customizable, and accessible library of foundational and advanced components, enabling you to build your own design system and develop React applications faster",
       "stars": 74159,
@@ -349,11 +351,11 @@
       "owner_id": 33663932,
       "icon": "material-ui.svg",
       "created_at": "2014-08-18T19:11:54.000Z",
-      "url": "https://mui.com/",
-      "slug": "material-ui"
+      "url": "https://mui.com/"
     },
     {
       "name": "Axios",
+      "slug": "axios",
       "full_name": "axios/axios",
       "description": "Promise based HTTP client for the browser and node.js",
       "stars": 90317,
@@ -363,11 +365,11 @@
       "owner_id": 32372333,
       "icon": "axios.svg",
       "created_at": "2014-08-18T22:30:27.000Z",
-      "url": "https://axios-http.com",
-      "slug": "axios"
+      "url": "https://axios-http.com"
     },
     {
       "name": "Vue Element Admin",
+      "slug": "vue-element-admin",
       "full_name": "PanJiaChen/vue-element-admin",
       "description": "A magical vue admin",
       "stars": 73403,
@@ -376,11 +378,11 @@
       "tags": ["vue", "dashboard"],
       "owner_id": 8121621,
       "icon": "vueelementadmin.png",
-      "created_at": "2017-04-17T03:35:49.000Z",
-      "slug": "vue-element-admin"
+      "created_at": "2017-04-17T03:35:49.000Z"
     },
     {
       "name": "Strapi",
+      "slug": "strapi",
       "full_name": "strapi/strapi",
       "description": "Open source Node.js Headless CMS to easily build customisable APIs",
       "stars": 42192,
@@ -392,11 +394,11 @@
       "owner_id": 19872173,
       "icon": "strapi.svg",
       "created_at": "2015-09-30T15:34:48.000Z",
-      "url": "https://strapi.io",
-      "slug": "strapi"
+      "url": "https://strapi.io"
     },
     {
       "name": "TypeScript",
+      "slug": "typescript",
       "full_name": "microsoft/TypeScript",
       "description": "A superset of JavaScript that compiles to clean JavaScript output.",
       "stars": 77104,
@@ -406,11 +408,11 @@
       "owner_id": 6154722,
       "icon": "typescript.svg",
       "created_at": "2014-06-17T15:28:39.000Z",
-      "url": "https://www.typescriptlang.org",
-      "slug": "typescript"
+      "url": "https://www.typescriptlang.org"
     },
     {
       "name": "Remix",
+      "slug": "remix",
       "full_name": "remix-run/remix",
       "description": "Build Better Websites. Create modern, resilient user experiences with web fundamentals.",
       "stars": 10539,
@@ -433,11 +435,11 @@
       "owner_id": 64235328,
       "icon": "remix.svg",
       "created_at": "2020-10-26T19:57:28.000Z",
-      "url": "https://remix.run",
-      "slug": "remix"
+      "url": "https://remix.run"
     },
     {
       "name": "Angular",
+      "slug": "angular",
       "full_name": "angular/angular",
       "description": "The modern web developer’s platform",
       "stars": 78700,
@@ -449,11 +451,11 @@
       "owner_id": 139426,
       "icon": "angular.svg",
       "created_at": "2014-09-18T16:12:01.000Z",
-      "url": "https://angular.io",
-      "slug": "angular"
+      "url": "https://angular.io"
     },
     {
       "name": "react-use",
+      "slug": "react-use",
       "full_name": "streamich/react-use",
       "description": "Collection of essential React Hooks",
       "stars": 27281,
@@ -462,11 +464,11 @@
       "tags": ["react", "hook"],
       "owner_id": 9773803,
       "created_at": "2018-10-27T10:16:05.000Z",
-      "url": "http://streamich.github.io/react-use",
-      "slug": "react-use"
+      "url": "http://streamich.github.io/react-use"
     },
     {
       "name": "Chakra UI",
+      "slug": "chakra-ui",
       "full_name": "chakra-ui/chakra-ui",
       "description": "Simple, Modular & Accessible UI Components for your React Applications",
       "stars": 23159,
@@ -476,11 +478,11 @@
       "owner_id": 54212428,
       "icon": "chakra-ui.svg",
       "created_at": "2019-08-17T14:27:54.000Z",
-      "url": "https://chakra-ui.com",
-      "slug": "chakra-ui"
+      "url": "https://chakra-ui.com"
     },
     {
       "name": "Cypress",
+      "slug": "cypress",
       "full_name": "cypress-io/cypress",
       "description": "Fast, easy and reliable testing for anything that runs in a browser.",
       "stars": 35833,
@@ -492,11 +494,11 @@
       "owner_id": 8908513,
       "icon": "cypress.svg",
       "created_at": "2015-03-04T00:46:28.000Z",
-      "url": "https://cypress.io",
-      "slug": "cypress"
+      "url": "https://cypress.io"
     },
     {
       "name": "swc",
+      "slug": "swc",
       "full_name": "swc-project/swc",
       "description": "A super-fast compiler written in rust",
       "stars": 19231,
@@ -508,11 +510,11 @@
       "owner_id": 26715726,
       "icon": "swc.svg",
       "created_at": "2017-12-22T11:40:14.000Z",
-      "url": "https://swc.rs",
-      "slug": "swc"
+      "url": "https://swc.rs"
     },
     {
       "name": "Astro",
+      "slug": "astro",
       "full_name": "withastro/astro",
       "description": "A static site builder that delivers lightning-fast performance with a modern developer experience",
       "stars": 8863,
@@ -535,11 +537,11 @@
       "owner_id": 44914786,
       "icon": "astro.svg",
       "created_at": "2021-03-15T17:19:47.000Z",
-      "url": "https://astro.build",
-      "slug": "astro"
+      "url": "https://astro.build"
     },
     {
       "name": "Deno",
+      "slug": "deno",
       "full_name": "denoland/deno",
       "description": "A modern runtime for JavaScript and TypeScript.",
       "stars": 79585,
@@ -551,11 +553,11 @@
       "owner_id": 42048915,
       "icon": "deno.svg",
       "created_at": "2018-05-15T01:34:26.000Z",
-      "url": "https://deno.land",
-      "slug": "deno"
+      "url": "https://deno.land"
     },
     {
       "name": "Headless UI",
+      "slug": "headless-ui",
       "full_name": "tailwindlabs/headlessui",
       "description": "Completely unstyled, fully accessible UI components, designed to integrate beautifully with Tailwind CSS.",
       "stars": 12504,
@@ -565,11 +567,11 @@
       "owner_id": 67109815,
       "icon": "headlessui.svg",
       "created_at": "2020-09-16T09:53:09.000Z",
-      "url": "https://headlessui.dev",
-      "slug": "headless-ui"
+      "url": "https://headlessui.dev"
     },
     {
       "name": "Bootstrap",
+      "slug": "bootstrap",
       "full_name": "twbs/bootstrap",
       "description": "The most popular HTML, CSS, and JavaScript framework for developing responsive, mobile first projects on the web.",
       "stars": 154780,
@@ -579,11 +581,11 @@
       "owner_id": 2918581,
       "icon": "bootstrap.svg",
       "created_at": "2011-07-29T21:19:00.000Z",
-      "url": "https://getbootstrap.com",
-      "slug": "bootstrap"
+      "url": "https://getbootstrap.com"
     },
     {
       "name": "Solid",
+      "slug": "solid",
       "full_name": "solidjs/solid",
       "description": "A declarative, efficient, and flexible JavaScript library for building user interfaces.",
       "stars": 13483,
@@ -593,11 +595,11 @@
       "owner_id": 79226042,
       "icon": "solid.svg",
       "created_at": "2018-04-24T16:36:27.000Z",
-      "url": "https://solidjs.com",
-      "slug": "solid"
+      "url": "https://solidjs.com"
     },
     {
       "name": "React Hook Form",
+      "slug": "react-hook-form",
       "full_name": "react-hook-form/react-hook-form",
       "description": "React Hooks for form state management and validation (Web + React Native)",
       "stars": 25176,
@@ -607,8 +609,7 @@
       "owner_id": 53986236,
       "icon": "react-hook-form.svg",
       "created_at": "2019-03-05T23:47:10.000Z",
-      "url": "https://react-hook-form.com",
-      "slug": "react-hook-form"
+      "url": "https://react-hook-form.com"
     },
     {
       "name": "React Query",
@@ -626,6 +627,7 @@
     },
     {
       "name": "Docusaurus",
+      "slug": "docusaurus",
       "full_name": "facebook/docusaurus",
       "description": "Easy to maintain open source documentation websites.",
       "stars": 29592,
@@ -635,11 +637,11 @@
       "owner_id": 69631,
       "icon": "docusaurus.svg",
       "created_at": "2017-06-20T16:13:53.000Z",
-      "url": "https://docusaurus.io",
-      "slug": "docusaurus"
+      "url": "https://docusaurus.io"
     },
     {
       "name": "nvm",
+      "slug": "nvm",
       "full_name": "nvm-sh/nvm",
       "description": "Node Version Manager - POSIX-compliant bash script to manage multiple active node.js versions",
       "stars": 54416,
@@ -647,11 +649,11 @@
       "monthly": [738, 828, 943, 756, 541, 789, 554, 644, 611, 802, 574, 546],
       "tags": ["nvm"],
       "owner_id": 49963700,
-      "created_at": "2010-04-15T17:47:47.000Z",
-      "slug": "nvm"
+      "created_at": "2010-04-15T17:47:47.000Z"
     },
     {
       "name": "Node.js",
+      "slug": "nodejs",
       "full_name": "nodejs/node",
       "description": "Node.js JavaScript runtime",
       "stars": 84120,
@@ -661,11 +663,11 @@
       "owner_id": 9950313,
       "icon": "nodejs.svg",
       "created_at": "2014-11-26T19:57:11.000Z",
-      "url": "https://nodejs.org",
-      "slug": "nodejs"
+      "url": "https://nodejs.org"
     },
     {
       "name": "React Native",
+      "slug": "react-native",
       "full_name": "facebook/react-native",
       "description": "A framework for building native applications using React",
       "stars": 100359,
@@ -675,11 +677,11 @@
       "owner_id": 69631,
       "icon": "react-native.svg",
       "created_at": "2015-01-09T18:10:16.000Z",
-      "url": "https://reactnative.dev/",
-      "slug": "react-native"
+      "url": "https://reactnative.dev/"
     },
     {
       "name": "Create React App",
+      "slug": "create-react-app",
       "full_name": "facebook/create-react-app",
       "description": "Set up a modern web app by running one command.",
       "stars": 92711,
@@ -689,11 +691,11 @@
       "owner_id": 69631,
       "icon": "cra.svg",
       "created_at": "2016-07-17T14:55:11.000Z",
-      "url": "https://create-react-app.dev",
-      "slug": "create-react-app"
+      "url": "https://create-react-app.dev"
     },
     {
       "name": "Puppeteer",
+      "slug": "puppeteer",
       "full_name": "puppeteer/puppeteer",
       "description": "Headless Chrome Node.js API",
       "stars": 75529,
@@ -703,11 +705,11 @@
       "owner_id": 6906516,
       "icon": "puppeteer.svg",
       "created_at": "2017-05-09T22:16:13.000Z",
-      "url": "https://pptr.dev/",
-      "slug": "puppeteer"
+      "url": "https://pptr.dev/"
     },
     {
       "name": "json-server",
+      "slug": "json-server",
       "full_name": "typicode/json-server",
       "description": "Get a full fake REST API with zero coding in less than 30 seconds (seriously)",
       "stars": 58895,
@@ -715,11 +717,11 @@
       "monthly": [728, 854, 546, 574, 663, 496, 524, 564, 696, 632, 611, 559],
       "tags": ["test", "filesystem"],
       "owner_id": 5502029,
-      "created_at": "2013-11-27T13:21:13.000Z",
-      "slug": "json-server"
+      "created_at": "2013-11-27T13:21:13.000Z"
     },
     {
       "name": "Naive UI",
+      "slug": "naive-ui",
       "full_name": "TuSimple/naive-ui",
       "description": "A Vue 3 Component Library. Fairly Complete. Customizable Themes. Uses TypeScript. Not too Slow.",
       "stars": 7385,
@@ -742,11 +744,11 @@
       "owner_id": 14118363,
       "icon": "naiveui.svg",
       "created_at": "2021-06-04T13:47:28.000Z",
-      "url": "https://www.naiveui.com",
-      "slug": "naive-ui"
+      "url": "https://www.naiveui.com"
     },
     {
       "name": "Alpine.js",
+      "slug": "alpinejs",
       "full_name": "alpinejs/alpine",
       "description": "A rugged, minimal framework for composing JavaScript behavior in your markup.",
       "stars": 19507,
@@ -756,13 +758,11 @@
       "owner_id": 59030169,
       "icon": "alpine.svg",
       "created_at": "2019-11-28T13:51:55.000Z",
-      "url": "https://alpinejs.dev",
-      "slug": "alpinejs"
+      "url": "https://alpinejs.dev"
     },
     {
       "name": "vue-next",
       "slug": "vuejs",
-      "ref": "vue-next",
       "full_name": "vuejs/vue-next",
       "description": "Vue.js is a progressive, incrementally-adoptable JavaScript framework for building UI on the web.",
       "stars": 26669,
@@ -771,10 +771,12 @@
       "tags": ["vue", "framework"],
       "owner_id": 6128107,
       "created_at": "2018-06-12T13:49:36.000Z",
-      "url": "https://v3.vuejs.org/"
+      "url": "https://v3.vuejs.org/",
+      "icon": "vue.svg"
     },
     {
       "name": "Zustand",
+      "slug": "zustand",
       "full_name": "pmndrs/zustand",
       "description": "Bear necessities for state management in React",
       "stars": 12673,
@@ -784,10 +786,11 @@
       "owner_id": 45790596,
       "created_at": "2019-04-09T09:10:06.000Z",
       "url": "https://zustand.surge.sh",
-      "slug": "zustand"
+      "icon": "zustand.webp"
     },
     {
       "name": "React Flow",
+      "slug": "react-flow",
       "full_name": "wbkd/react-flow",
       "description": "Highly customizable library for building interactive node-based UIs, editors, flow charts and diagrams",
       "stars": 8534,
@@ -797,11 +800,11 @@
       "owner_id": 7106853,
       "icon": "react-flow.svg",
       "created_at": "2019-07-15T14:47:30.000Z",
-      "url": "https://reactflow.dev",
-      "slug": "react-flow"
+      "url": "https://reactflow.dev"
     },
     {
       "name": "Nuxt",
+      "slug": "nuxt",
       "full_name": "nuxt/nuxt.js",
       "description": "The Intuitive Vue(2) Framework",
       "stars": 39128,
@@ -809,13 +812,13 @@
       "monthly": [244, 324, 391, 471, 424, 464, 414, 416, 794, 950, 653, 711],
       "tags": ["vue", "universal", "nodejs-framework", "ssg"],
       "owner_id": 23360933,
-      "icon": "nuxt2.svg",
+      "icon": "nuxt.svg",
       "created_at": "2016-10-26T11:18:47.000Z",
-      "url": "https://nuxtjs.org",
-      "slug": "nuxt"
+      "url": "https://nuxtjs.org"
     },
     {
       "name": "SvelteKit",
+      "slug": "sveltekit",
       "full_name": "sveltejs/kit",
       "description": "The fastest way to build Svelte apps",
       "stars": 6416,
@@ -837,11 +840,11 @@
       "tags": ["svelte", "fullstack", "nodejs-framework"],
       "owner_id": 23617963,
       "created_at": "2020-10-15T14:00:23.000Z",
-      "url": "https://kit.svelte.dev",
-      "slug": "sveltekit"
+      "url": "https://kit.svelte.dev"
     },
     {
       "name": "Element Plus",
+      "slug": "element-plus",
       "full_name": "element-plus/element-plus",
       "description": "A Vue.js 3 UI Library made by Element team",
       "stars": 13417,
@@ -850,11 +853,11 @@
       "tags": ["component", "vue"],
       "owner_id": 68583457,
       "created_at": "2020-07-21T06:51:19.000Z",
-      "url": "https://element-plus.org",
-      "slug": "element-plus"
+      "url": "https://element-plus.org"
     },
     {
       "name": "swr",
+      "slug": "swr",
       "full_name": "vercel/swr",
       "description": "React Hooks for data fetching",
       "stars": 20603,
@@ -864,11 +867,11 @@
       "owner_id": 14985020,
       "icon": "swr.svg",
       "created_at": "2019-10-28T18:16:01.000Z",
-      "url": "https://swr.vercel.app",
-      "slug": "swr"
+      "url": "https://swr.vercel.app"
     },
     {
       "name": "petite-vue",
+      "slug": "petite-vue",
       "full_name": "vuejs/petite-vue",
       "description": "6kb subset of Vue optimized for progressive enhancement",
       "stars": 5524,
@@ -889,11 +892,11 @@
       ],
       "tags": ["vue", "framework"],
       "owner_id": 6128107,
-      "created_at": "2021-07-01T04:22:47.000Z",
-      "slug": "petite-vue"
+      "created_at": "2021-07-01T04:22:47.000Z"
     },
     {
       "name": "Hasura GraphQL Engine",
+      "slug": "hasura-graphql-engine",
       "full_name": "hasura/graphql-engine",
       "description": "Blazing fast, instant realtime GraphQL APIs on your DB with fine grained access control, also trigger webhooks on database events.",
       "stars": 25022,
@@ -903,11 +906,11 @@
       "owner_id": 13966722,
       "icon": "hasura.svg",
       "created_at": "2018-06-18T07:57:36.000Z",
-      "url": "https://hasura.io",
-      "slug": "hasura-graphql-engine"
+      "url": "https://hasura.io"
     },
     {
       "name": "tiptap",
+      "slug": "tiptap",
       "full_name": "ueberdosis/tiptap",
       "description": "The headless editor framework for web artisans.",
       "stars": 13838,
@@ -916,11 +919,11 @@
       "tags": ["vue", "rich-text-editor"],
       "owner_id": 16939337,
       "created_at": "2018-08-20T19:58:58.000Z",
-      "url": "https://tiptap.dev",
-      "slug": "tiptap"
+      "url": "https://tiptap.dev"
     },
     {
       "name": "react-three-fiber",
+      "slug": "react-three-fiber",
       "full_name": "pmndrs/react-three-fiber",
       "description": "A React renderer for Three.js",
       "stars": 16323,
@@ -929,11 +932,11 @@
       "tags": ["react", "3d"],
       "owner_id": 45790596,
       "created_at": "2019-02-25T14:31:51.000Z",
-      "url": "https://docs.pmnd.rs/react-three-fiber",
-      "slug": "react-three-fiber"
+      "url": "https://docs.pmnd.rs/react-three-fiber"
     },
     {
       "name": "Fastify",
+      "slug": "fastify",
       "full_name": "fastify/fastify",
       "description": "Fast and low overhead web framework, for Node.js",
       "stars": 21683,
@@ -943,11 +946,11 @@
       "owner_id": 24939410,
       "icon": "fastify.svg",
       "created_at": "2016-09-28T19:10:14.000Z",
-      "url": "https://www.fastify.io",
-      "slug": "fastify"
+      "url": "https://www.fastify.io"
     },
     {
       "name": "VueUse",
+      "slug": "vueuse",
       "full_name": "vueuse/vueuse",
       "description": "Collection of essential Vue Composition Utilities for Vue 2 and 3",
       "stars": 7496,
@@ -956,11 +959,11 @@
       "tags": ["vue", "util"],
       "owner_id": 77578415,
       "created_at": "2019-12-14T06:44:59.000Z",
-      "url": "https://vueuse.org",
-      "slug": "vueuse"
+      "url": "https://vueuse.org"
     },
     {
       "name": "Blitz",
+      "slug": "blitz",
       "full_name": "blitz-js/blitz",
       "description": "The Fullstack React Framework — built on Next.js",
       "stars": 10570,
@@ -969,11 +972,11 @@
       "tags": ["fullstack", "react", "nodejs-framework", "nextjs"],
       "owner_id": 61243378,
       "created_at": "2020-02-17T21:54:15.000Z",
-      "url": "https://Blitzjs.com",
-      "slug": "blitz"
+      "url": "https://Blitzjs.com"
     },
     {
       "name": "Redwood",
+      "slug": "redwood",
       "full_name": "redwoodjs/redwood",
       "description": "The App Framework for Startups",
       "stars": 10503,
@@ -983,11 +986,11 @@
       "owner_id": 45050444,
       "icon": "redwood.svg",
       "created_at": "2019-06-09T20:17:57.000Z",
-      "url": "https://redwoodjs.com",
-      "slug": "redwood"
+      "url": "https://redwoodjs.com"
     },
     {
       "name": "Remotion",
+      "slug": "remotion",
       "full_name": "remotion-dev/remotion",
       "description": "Create videos programmatically in React",
       "stars": 8930,
@@ -996,11 +999,11 @@
       "tags": ["video", "react"],
       "owner_id": 85344006,
       "created_at": "2020-06-23T19:49:10.000Z",
-      "url": "https://remotion.dev",
-      "slug": "remotion"
+      "url": "https://remotion.dev"
     },
     {
       "name": "Turborepo",
+      "slug": "turborepo",
       "full_name": "vercel/turborepo",
       "description": "The High-performance Build System for JavaScript & TypeScript Codebases",
       "stars": 4776,
@@ -1023,11 +1026,11 @@
       "owner_id": 14985020,
       "icon": "turborepo.svg",
       "created_at": "2021-10-05T17:37:11.000Z",
-      "url": "https://turborepo.org",
-      "slug": "turborepo"
+      "url": "https://turborepo.org"
     },
     {
       "name": "Framer Motion",
+      "slug": "framer-motion",
       "full_name": "framer/motion",
       "description": "Production-ready animation and gesture library for React",
       "stars": 13360,
@@ -1037,11 +1040,11 @@
       "owner_id": 42876,
       "icon": "motion.svg",
       "created_at": "2018-11-16T09:48:38.000Z",
-      "url": "https://framer.com/motion",
-      "slug": "framer-motion"
+      "url": "https://framer.com/motion"
     },
     {
       "name": "vanilla-extract",
+      "slug": "vanilla-extract",
       "full_name": "seek-oss/vanilla-extract",
       "description": "Zero-runtime Stylesheets-in-TypeScript",
       "stars": 4506,
@@ -1051,11 +1054,11 @@
       "owner_id": 22927121,
       "icon": "vanilla.svg",
       "created_at": "2021-03-26T05:10:54.000Z",
-      "url": "https://vanilla-extract.style",
-      "slug": "vanilla-extract"
+      "url": "https://vanilla-extract.style"
     },
     {
       "name": "Nx",
+      "slug": "nx",
       "full_name": "nrwl/nx",
       "description": "Smart, Fast and Extensible Build System",
       "stars": 10045,
@@ -1065,11 +1068,11 @@
       "owner_id": 23692104,
       "icon": "nx.svg",
       "created_at": "2017-08-12T00:00:00.000Z",
-      "url": "https://nx.dev",
-      "slug": "nx"
+      "url": "https://nx.dev"
     },
     {
       "name": "XState",
+      "slug": "xstate",
       "full_name": "statelyai/xstate",
       "description": "State machines and statecharts for the modern web.",
       "stars": 18486,
@@ -1079,11 +1082,11 @@
       "owner_id": 61783956,
       "icon": "xstate.svg",
       "created_at": "2015-09-14T15:04:15.000Z",
-      "url": "https://xstate.js.org/docs",
-      "slug": "xstate"
+      "url": "https://xstate.js.org/docs"
     },
     {
       "name": "Jotai",
+      "slug": "jotai",
       "full_name": "pmndrs/jotai",
       "description": "Primitive and flexible state management for React",
       "stars": 6739,
@@ -1093,10 +1096,11 @@
       "owner_id": 45790596,
       "created_at": "2020-08-11T23:15:36.000Z",
       "url": "https://jotai.org",
-      "slug": "jotai"
+      "icon": "jotai.webp"
     },
     {
       "name": "Recoil",
+      "slug": "recoil",
       "full_name": "facebookexperimental/Recoil",
       "description": "An experimental state management library for React apps",
       "stars": 15361,
@@ -1106,11 +1110,11 @@
       "owner_id": 12853545,
       "icon": "recoil.svg",
       "created_at": "2020-05-04T19:44:15.000Z",
-      "url": "https://recoiljs.org/",
-      "slug": "recoil"
+      "url": "https://recoiljs.org/"
     },
     {
       "name": "Express",
+      "slug": "express",
       "full_name": "expressjs/express",
       "description": "Fast, unopinionated, minimalist web framework for node.",
       "stars": 55532,
@@ -1120,11 +1124,11 @@
       "owner_id": 5658226,
       "icon": "express.svg",
       "created_at": "2009-06-26T18:56:01.000Z",
-      "url": "https://expressjs.com",
-      "slug": "express"
+      "url": "https://expressjs.com"
     },
     {
       "name": "Nuxt 3",
+      "slug": "nuxt-3",
       "full_name": "nuxt/framework",
       "description": "The Hybrid Vue(3) Framework.",
       "stars": 4085,
@@ -1147,11 +1151,11 @@
       "owner_id": 23360933,
       "icon": "nuxt.svg",
       "created_at": "2021-03-17T19:07:24.000Z",
-      "url": "https://v3.nuxtjs.org",
-      "slug": "nuxt-3"
+      "url": "https://v3.nuxtjs.org"
     },
     {
       "name": "Jest",
+      "slug": "jest",
       "full_name": "facebook/jest",
       "description": "Delightful JavaScript Testing.",
       "stars": 37554,
@@ -1161,11 +1165,11 @@
       "owner_id": 69631,
       "icon": "jest.svg",
       "created_at": "2013-12-10T00:18:04.000Z",
-      "url": "https://jestjs.io",
-      "slug": "jest"
+      "url": "https://jestjs.io"
     },
     {
       "name": "Gatsby",
+      "slug": "gatsby",
       "full_name": "gatsbyjs/gatsby",
       "description": "Build blazing fast, modern apps and websites with React",
       "stars": 52114,
@@ -1175,11 +1179,11 @@
       "owner_id": 12551863,
       "icon": "gatsby.svg",
       "created_at": "2015-05-21T22:43:05.000Z",
-      "url": "https://www.gatsbyjs.com",
-      "slug": "gatsby"
+      "url": "https://www.gatsbyjs.com"
     },
     {
       "name": "Styled Components",
+      "slug": "styled-components",
       "full_name": "styled-components/styled-components",
       "description": "Visual primitives for the component age. Use the best bits of ES6 and CSS to style your apps without stress",
       "stars": 35634,
@@ -1188,11 +1192,11 @@
       "tags": ["css-in-js"],
       "owner_id": 20658825,
       "created_at": "2016-08-16T06:41:32.000Z",
-      "url": "https://styled-components.com",
-      "slug": "styled-components"
+      "url": "https://styled-components.com"
     },
     {
       "name": "Mock Service Worker",
+      "slug": "mock-service-worker",
       "full_name": "mswjs/msw",
       "description": "Seamless REST/GraphQL API mocking library for browser and Node.js.",
       "stars": 8005,
@@ -1201,11 +1205,11 @@
       "tags": ["test", "serviceworker"],
       "owner_id": 64637271,
       "created_at": "2018-11-13T14:58:44.000Z",
-      "url": "https://mswjs.io",
-      "slug": "mock-service-worker"
+      "url": "https://mswjs.io"
     },
     {
       "name": "Webpack",
+      "slug": "webpack",
       "full_name": "webpack/webpack",
       "description": "A bundler for javascript and friends. Packs many modules into a few bundled assets. Code Splitting allows for loading parts of the application on demand. Through \"loaders\", modules can be CommonJs, AMD, ES6 modules, CSS, Images, JSON, Coffeescript, LESS, ... and your custom stuff.",
       "stars": 60190,
@@ -1215,11 +1219,11 @@
       "owner_id": 2105791,
       "icon": "webpack.svg",
       "created_at": "2012-03-10T10:08:14.000Z",
-      "url": "https://webpack.js.org",
-      "slug": "webpack"
+      "url": "https://webpack.js.org"
     },
     {
       "name": "Ionic",
+      "slug": "ionic",
       "full_name": "ionic-team/ionic-framework",
       "description": "A powerful cross-platform UI toolkit for building native-quality iOS, Android, and Progressive Web Apps with HTML, CSS, and JavaScript.",
       "stars": 45918,
@@ -1229,11 +1233,11 @@
       "owner_id": 3171503,
       "icon": "ionic.svg",
       "created_at": "2013-08-20T23:06:02.000Z",
-      "url": "https://ionicframework.com",
-      "slug": "ionic"
+      "url": "https://ionicframework.com"
     },
     {
       "name": "Expo",
+      "slug": "expo",
       "full_name": "expo/expo",
       "description": "An open-source platform for making universal native apps with React. Expo runs on Android, iOS, and the web.",
       "stars": 15676,
@@ -1243,11 +1247,11 @@
       "owner_id": 12504344,
       "icon": "expo.svg",
       "created_at": "2016-08-15T17:14:25.000Z",
-      "url": "https://docs.expo.dev",
-      "slug": "expo"
+      "url": "https://docs.expo.dev"
     },
     {
       "name": "Lit",
+      "slug": "lit",
       "full_name": "lit/lit",
       "description": "A simple library for building fast, lightweight web components",
       "stars": 9979,
@@ -1257,11 +1261,11 @@
       "owner_id": 18489846,
       "icon": "lit.svg",
       "created_at": "2017-06-29T16:27:16.000Z",
-      "url": "https://lit.dev",
-      "slug": "lit"
+      "url": "https://lit.dev"
     },
     {
       "name": "Quasar",
+      "slug": "quasar",
       "full_name": "quasarframework/quasar",
       "description": "Responsive Single Page Apps, Server-side Render Apps, Progressive Web Apps, Hybrid Mobile Apps (that look native!) & Electron Apps, all using the same codebase.",
       "stars": 20205,
@@ -1271,11 +1275,11 @@
       "owner_id": 23064371,
       "icon": "quasar.svg",
       "created_at": "2015-10-05T15:45:36.000Z",
-      "url": "https://quasar.dev",
-      "slug": "quasar"
+      "url": "https://quasar.dev"
     },
     {
       "name": "Pinia",
+      "slug": "pinia",
       "full_name": "vuejs/pinia",
       "description": "Intuitive, type safe, light and flexible Store for Vue using the composition api with DevTools support",
       "stars": 4654,
@@ -1298,11 +1302,11 @@
       "owner_id": 6128107,
       "icon": "pinia.svg",
       "created_at": "2019-11-18T21:05:01.000Z",
-      "url": "https://pinia.vuejs.org",
-      "slug": "pinia"
+      "url": "https://pinia.vuejs.org"
     },
     {
       "name": "Gun",
+      "slug": "gun",
       "full_name": "amark/gun",
       "description": "An open source cybersecurity protocol for syncing decentralized graph data.",
       "stars": 15292,
@@ -1312,11 +1316,11 @@
       "owner_id": 433412,
       "icon": "gun.svg",
       "created_at": "2014-07-31T15:52:10.000Z",
-      "url": "https://gun.eco/docs",
-      "slug": "gun"
+      "url": "https://gun.eco/docs"
     },
     {
       "name": "Stitches",
+      "slug": "stitches",
       "full_name": "modulz/stitches",
       "description": "CSS-in-JS with near-zero runtime, SSR, multi-variant support, and a best-in-class developer experience.",
       "stars": 4490,
@@ -1326,11 +1330,11 @@
       "owner_id": 28682402,
       "icon": "stitches.svg",
       "created_at": "2020-04-14T07:07:35.000Z",
-      "url": "https://stitches.dev",
-      "slug": "stitches"
+      "url": "https://stitches.dev"
     },
     {
       "name": "Eleventy",
+      "slug": "eleventy",
       "full_name": "11ty/eleventy",
       "description": "A simpler static site generator. An alternative to Jekyll. Transforms a directory of templates (of varying types) into HTML.",
       "stars": 10982,
@@ -1339,11 +1343,11 @@
       "tags": ["ssg"],
       "owner_id": 35147177,
       "created_at": "2017-11-27T05:19:00.000Z",
-      "url": "https://www.11ty.dev/",
-      "slug": "eleventy"
+      "url": "https://www.11ty.dev/"
     },
     {
       "name": "rrweb",
+      "slug": "rrweb",
       "full_name": "rrweb-io/rrweb",
       "description": "record and replay the web",
       "stars": 10941,
@@ -1352,11 +1356,11 @@
       "tags": ["debug", "auto"],
       "owner_id": 43396833,
       "created_at": "2018-10-06T13:35:55.000Z",
-      "url": "https://www.rrweb.io/",
-      "slug": "rrweb"
+      "url": "https://www.rrweb.io/"
     },
     {
       "name": "htmx",
+      "slug": "htmx",
       "full_name": "bigskysoftware/htmx",
       "description": "</> htmx - high power tools for HTML",
       "stars": 5446,
@@ -1366,11 +1370,11 @@
       "owner_id": 48798027,
       "icon": "htmx.svg",
       "created_at": "2020-04-13T16:17:51.000Z",
-      "url": "https://htmx.org",
-      "slug": "htmx"
+      "url": "https://htmx.org"
     },
     {
       "name": "Preact",
+      "slug": "preact",
       "full_name": "preactjs/preact",
       "description": "Fast 3kB React alternative with the same modern API. Components & Virtual DOM.",
       "stars": 30654,
@@ -1380,11 +1384,11 @@
       "owner_id": 26872990,
       "icon": "preact.svg",
       "created_at": "2015-09-11T02:40:18.000Z",
-      "url": "https://preactjs.com",
-      "slug": "preact"
+      "url": "https://preactjs.com"
     },
     {
       "name": "Rome",
+      "slug": "rome",
       "full_name": "rome/tools",
       "description": "The Rome Toolchain. A linter, compiler, bundler, and more for JavaScript, TypeScript, HTML, Markdown, and CSS.",
       "stars": 16920,
@@ -1394,11 +1398,11 @@
       "owner_id": 85328842,
       "icon": "rome.svg",
       "created_at": "2020-02-20T05:57:33.000Z",
-      "url": "https://rome.tools/",
-      "slug": "rome"
+      "url": "https://rome.tools/"
     },
     {
       "name": "Svelte NodeGUI",
+      "slug": "svelte-nodegui",
       "full_name": "nodegui/svelte-nodegui",
       "description": "Build performant, native and cross-platform desktop applications with native Svelte + powerful CSS-like styling.",
       "stars": 2608,
@@ -1408,11 +1412,11 @@
       "owner_id": 51644128,
       "icon": "nodegui.svg",
       "created_at": "2021-01-29T18:29:07.000Z",
-      "url": "https://svelte.nodegui.org/",
-      "slug": "svelte-nodegui"
+      "url": "https://svelte.nodegui.org/"
     },
     {
       "name": "tRPC",
+      "slug": "trpc",
       "full_name": "trpc/trpc",
       "description": "End-to-end typesafe APIs made easy",
       "stars": 2672,
@@ -1429,10 +1433,11 @@
       "owner_id": 78011399,
       "created_at": "2020-07-18T01:17:11.000Z",
       "url": "https://tRPC.io",
-      "slug": "trpc"
+      "icon": "trpc.svg"
     },
     {
       "name": "Adonis",
+      "slug": "adonis",
       "full_name": "adonisjs/core",
       "description": "The Node.js Framework highly focused on developer ergonomics, stability and confidence",
       "stars": 11795,
@@ -1441,11 +1446,11 @@
       "tags": ["nodejs-framework"],
       "owner_id": 13810373,
       "created_at": "2015-08-15T17:03:54.000Z",
-      "url": "https://adonisjs.com",
-      "slug": "adonis"
+      "url": "https://adonisjs.com"
     },
     {
       "name": "Flipper",
+      "slug": "flipper",
       "full_name": "facebook/flipper",
       "description": "A desktop debugging platform for mobile developers.",
       "stars": 10387,
@@ -1454,11 +1459,11 @@
       "tags": ["mobile", "devtool"],
       "owner_id": 69631,
       "created_at": "2018-04-12T16:47:36.000Z",
-      "url": "https://fbflipper.com/",
-      "slug": "flipper"
+      "url": "https://fbflipper.com/"
     },
     {
       "name": "Keystone",
+      "slug": "keystone",
       "full_name": "keystonejs/keystone",
       "description": "The most powerful headless CMS for Node.js — built with GraphQL and React",
       "stars": 5548,
@@ -1468,11 +1473,11 @@
       "owner_id": 6118534,
       "icon": "keystone.svg",
       "created_at": "2018-04-05T10:48:37.000Z",
-      "url": "https://keystonejs.com",
-      "slug": "keystone"
+      "url": "https://keystonejs.com"
     },
     {
       "name": "Parcel",
+      "slug": "parcel",
       "full_name": "parcel-bundler/parcel",
       "description": "The zero configuration build tool for the web.",
       "stars": 39759,
@@ -1482,11 +1487,11 @@
       "owner_id": 32607881,
       "icon": "parcel.svg",
       "created_at": "2017-08-07T16:36:47.000Z",
-      "url": "https://parceljs.org",
-      "slug": "parcel"
+      "url": "https://parceljs.org"
     },
     {
       "name": "Twin",
+      "slug": "twin",
       "full_name": "ben-rogerson/twin.macro",
       "description": "Twin blends the magic of Tailwind with the flexibility of css-in-js (emotion, styled-components, stitches and goober) at build time.",
       "stars": 5205,
@@ -1494,11 +1499,11 @@
       "monthly": [131, 155, 142, 162, 132, 135, 138, 189, 207, 278, 321, 321],
       "tags": ["css-in-js", "react"],
       "owner_id": 21288568,
-      "created_at": "2020-02-19T04:45:25.000Z",
-      "slug": "twin"
+      "created_at": "2020-02-19T04:45:25.000Z"
     },
     {
       "name": "Redux",
+      "slug": "redux",
       "full_name": "reduxjs/redux",
       "description": "Predictable state container for JavaScript apps",
       "stars": 57294,
@@ -1508,11 +1513,11 @@
       "owner_id": 13142323,
       "icon": "redux.svg",
       "created_at": "2015-05-29T23:53:15.000Z",
-      "url": "https://redux.js.org",
-      "slug": "redux"
+      "url": "https://redux.js.org"
     },
     {
       "name": "react-testing-library",
+      "slug": "react-testing-library",
       "full_name": "testing-library/react-testing-library",
       "description": "Simple and complete React DOM testing utilities that encourage good testing practices.",
       "stars": 15722,
@@ -1521,11 +1526,11 @@
       "tags": ["test", "react"],
       "owner_id": 49996085,
       "created_at": "2018-03-19T13:39:49.000Z",
-      "url": "https://testing-library.com/react",
-      "slug": "react-testing-library"
+      "url": "https://testing-library.com/react"
     },
     {
       "name": "Hexo",
+      "slug": "hexo",
       "full_name": "hexojs/hexo",
       "description": "A fast, simple & powerful blog framework, powered by Node.js.",
       "stars": 33996,
@@ -1535,11 +1540,11 @@
       "owner_id": 6375567,
       "icon": "hexo.svg",
       "created_at": "2012-09-23T15:17:08.000Z",
-      "url": "https://hexo.io",
-      "slug": "hexo"
+      "url": "https://hexo.io"
     },
     {
       "name": "umi",
+      "slug": "umi",
       "full_name": "umijs/umi",
       "description": "Pluggable enterprise-level react application framework.",
       "stars": 11800,
@@ -1548,11 +1553,11 @@
       "tags": ["nodejs-framework", "react"],
       "owner_id": 33895495,
       "created_at": "2017-11-22T10:09:36.000Z",
-      "url": "https://umijs.org",
-      "slug": "umi"
+      "url": "https://umijs.org"
     },
     {
       "name": "GraphQL Code Generator",
+      "slug": "graphql-code-generator",
       "full_name": "dotansimha/graphql-code-generator",
       "description": "A tool for generating code based on a GraphQL schema and GraphQL operations (query/mutation/subscription), with flexible support for custom plugins.",
       "stars": 8099,
@@ -1562,11 +1567,11 @@
       "owner_id": 3680083,
       "icon": "graphql-code-generator.svg",
       "created_at": "2016-12-05T19:15:11.000Z",
-      "url": "https://graphql-code-generator.com",
-      "slug": "graphql-code-generator"
+      "url": "https://graphql-code-generator.com"
     },
     {
       "name": "Emotion",
+      "slug": "emotion",
       "full_name": "emotion-js/emotion",
       "description": "CSS-in-JS library designed for high performance style composition",
       "stars": 14258,
@@ -1575,11 +1580,11 @@
       "tags": ["css-in-js"],
       "owner_id": 31557565,
       "created_at": "2017-05-27T04:23:45.000Z",
-      "url": "https://emotion.sh/",
-      "slug": "emotion"
+      "url": "https://emotion.sh/"
     },
     {
       "name": "Valtio",
+      "slug": "valtio",
       "full_name": "pmndrs/valtio",
       "description": "Valtio makes proxy-state simple  for React and Vanilla",
       "stars": 3575,
@@ -1588,11 +1593,11 @@
       "tags": ["state", "react"],
       "owner_id": 45790596,
       "created_at": "2020-11-16T22:30:51.000Z",
-      "url": "http://valtio-demo.pmnd.rs",
-      "slug": "valtio"
+      "url": "http://valtio-demo.pmnd.rs"
     },
     {
       "name": "Linaria",
+      "slug": "linaria",
       "full_name": "callstack/linaria",
       "description": "Zero-runtime CSS in JS library",
       "stars": 8489,
@@ -1602,11 +1607,11 @@
       "owner_id": 42239399,
       "icon": "linaria.svg",
       "created_at": "2017-05-23T00:52:34.000Z",
-      "url": "https://linaria.dev",
-      "slug": "linaria"
+      "url": "https://linaria.dev"
     },
     {
       "name": "Vitest",
+      "slug": "vitest",
       "full_name": "vitest-dev/vitest",
       "description": "A Vite-native test framework. It's fast!",
       "stars": 2131,
@@ -1629,11 +1634,11 @@
       "owner_id": 95747107,
       "icon": "vitest.svg",
       "created_at": "2021-12-03T19:19:49.000Z",
-      "url": "https://vitest.dev",
-      "slug": "vitest"
+      "url": "https://vitest.dev"
     },
     {
       "name": "Apollo client",
+      "slug": "apollo-client",
       "full_name": "apollographql/apollo-client",
       "description": "A fully-featured, production ready caching GraphQL client for every UI framework and GraphQL server.",
       "stars": 17144,
@@ -1643,11 +1648,11 @@
       "owner_id": 17189275,
       "icon": "apollo.svg",
       "created_at": "2016-02-26T20:25:00.000Z",
-      "url": "https://apollographql.com/client",
-      "slug": "apollo-client"
+      "url": "https://apollographql.com/client"
     },
     {
       "name": "Capacitor",
+      "slug": "capacitor",
       "full_name": "ionic-team/capacitor",
       "description": "Build cross-platform Native Progressive Web Apps for iOS, Android, and the Web",
       "stars": 6677,
@@ -1656,11 +1661,11 @@
       "tags": ["mobile"],
       "owner_id": 3171503,
       "created_at": "2017-11-18T21:38:09.000Z",
-      "url": "https://capacitorjs.com",
-      "slug": "capacitor"
+      "url": "https://capacitorjs.com"
     },
     {
       "name": "NodeGUI",
+      "slug": "nodegui",
       "full_name": "nodegui/nodegui",
       "description": "A library for building cross-platform native desktop applications with Node.js and CSS",
       "stars": 7376,
@@ -1670,11 +1675,11 @@
       "owner_id": 51644128,
       "icon": "nodegui.svg",
       "created_at": "2019-05-14T16:41:17.000Z",
-      "url": "http://docs.nodegui.org",
-      "slug": "nodegui"
+      "url": "http://docs.nodegui.org"
     },
     {
       "name": "Neutralino",
+      "slug": "neutralino",
       "full_name": "neutralinojs/neutralinojs",
       "description": "Portable and lightweight cross-platform desktop application development framework",
       "stars": 4829,
@@ -1683,11 +1688,11 @@
       "tags": ["desktop"],
       "owner_id": 36976817,
       "created_at": "2018-06-23T03:30:41.000Z",
-      "url": "https://neutralino.js.org",
-      "slug": "neutralino"
+      "url": "https://neutralino.js.org"
     },
     {
       "name": "Vuex",
+      "slug": "vuex",
       "full_name": "vuejs/vuex",
       "description": "Centralized State Management for Vue.js.",
       "stars": 27196,
@@ -1696,11 +1701,11 @@
       "tags": ["flux", "vue", "state"],
       "owner_id": 6128107,
       "created_at": "2015-07-16T04:21:26.000Z",
-      "url": "https://vuex.vuejs.org",
-      "slug": "vuex"
+      "url": "https://vuex.vuejs.org"
     },
     {
       "name": "MobX",
+      "slug": "mobx",
       "full_name": "mobxjs/mobx",
       "description": "Simple, scalable state management.",
       "stars": 24699,
@@ -1710,11 +1715,11 @@
       "owner_id": 17475736,
       "icon": "mobx.svg",
       "created_at": "2015-03-14T14:31:38.000Z",
-      "url": "http://mobx.js.org",
-      "slug": "mobx"
+      "url": "http://mobx.js.org"
     },
     {
       "name": "VuePress",
+      "slug": "vuepress",
       "full_name": "vuejs/vuepress",
       "description": "Minimalistic Vue-powered static site generator",
       "stars": 19813,
@@ -1723,11 +1728,11 @@
       "tags": ["vue", "ssg"],
       "owner_id": 6128107,
       "created_at": "2018-04-05T16:58:38.000Z",
-      "url": "https://vuepress.vuejs.org",
-      "slug": "vuepress"
+      "url": "https://vuepress.vuejs.org"
     },
     {
       "name": "Koa",
+      "slug": "koa",
       "full_name": "koajs/koa",
       "description": "Expressive middleware for node.js using ES2017 async functions",
       "stars": 32157,
@@ -1736,11 +1741,11 @@
       "tags": ["nodejs-framework"],
       "owner_id": 5055057,
       "created_at": "2013-07-20T18:53:45.000Z",
-      "url": "https://koajs.com",
-      "slug": "koa"
+      "url": "https://koajs.com"
     },
     {
       "name": "electron-builder",
+      "slug": "electron-builder",
       "full_name": "electron-userland/electron-builder",
       "description": "A complete solution to package and build a ready for distribution Electron app with “auto update” support out of the box",
       "stars": 11698,
@@ -1749,11 +1754,11 @@
       "tags": ["desktop"],
       "owner_id": 17519142,
       "created_at": "2015-05-21T07:45:02.000Z",
-      "url": "https://www.electron.build",
-      "slug": "electron-builder"
+      "url": "https://www.electron.build"
     },
     {
       "name": "jsdom",
+      "slug": "jsdom",
       "full_name": "jsdom/jsdom",
       "description": "A JavaScript implementation of various web standards, for use with Node.js",
       "stars": 16808,
@@ -1762,11 +1767,11 @@
       "tags": ["test"],
       "owner_id": 9271229,
       "icon": "jsdom.svg",
-      "created_at": "2010-01-19T06:55:19.000Z",
-      "slug": "jsdom"
+      "created_at": "2010-01-19T06:55:19.000Z"
     },
     {
       "name": "Directus",
+      "slug": "directus",
       "full_name": "directus/directus",
       "description": "A real-time API and App dashboard for managing SQL database content.",
       "stars": 13365,
@@ -1788,11 +1793,11 @@
       "tags": ["nodejs-framework", "cms", "graphql", "vue", "sql"],
       "owner_id": 15967950,
       "created_at": "2012-12-12T01:35:36.000Z",
-      "url": "https://directus.io",
-      "slug": "directus"
+      "url": "https://directus.io"
     },
     {
       "name": "Rollup",
+      "slug": "rollup",
       "full_name": "rollup/rollup",
       "description": "Next-generation ES module bundler",
       "stars": 21059,
@@ -1802,11 +1807,11 @@
       "owner_id": 12554859,
       "icon": "rollup.svg",
       "created_at": "2015-05-14T22:26:28.000Z",
-      "url": "https://rollupjs.org",
-      "slug": "rollup"
+      "url": "https://rollupjs.org"
     },
     {
       "name": "Nativefier",
+      "slug": "nativefier",
       "full_name": "nativefier/nativefier",
       "description": "Make any web page a desktop application",
       "stars": 29509,
@@ -1827,11 +1832,11 @@
       ],
       "tags": ["desktop"],
       "owner_id": 69503009,
-      "created_at": "2015-07-05T05:56:42.000Z",
-      "slug": "nativefier"
+      "created_at": "2015-07-05T05:56:42.000Z"
     },
     {
       "name": "Twind",
+      "slug": "twind",
       "full_name": "tw-in-js/twind",
       "description": "The smallest, fastest, most feature complete Tailwind-in-JS solution in existence.",
       "stars": 1894,
@@ -1840,11 +1845,11 @@
       "tags": ["css-in-js"],
       "owner_id": 75540906,
       "created_at": "2020-12-05T17:59:21.000Z",
-      "url": "https://twind.dev",
-      "slug": "twind"
+      "url": "https://twind.dev"
     },
     {
       "name": "GraphiQL",
+      "slug": "graphiql",
       "full_name": "graphql/graphiql",
       "description": "GraphiQL & the GraphQL LSP Reference Ecosystem for building browser & IDE tools.",
       "stars": 13035,
@@ -1852,11 +1857,11 @@
       "monthly": [84, 125, 101, 97, 98, 117, 98, 244, 129, 128, 111, 131],
       "tags": ["graphql"],
       "owner_id": 12972006,
-      "created_at": "2015-08-11T02:56:22.000Z",
-      "slug": "graphiql"
+      "created_at": "2015-08-11T02:56:22.000Z"
     },
     {
       "name": "Apollo Server",
+      "slug": "apollo-server",
       "full_name": "apollographql/apollo-server",
       "description": "Spec-compliant and production ready JavaScript GraphQL server that lets you develop in a schema-first way. Built for Express, Connect, Hapi, Koa, and more.",
       "stars": 12205,
@@ -1866,11 +1871,11 @@
       "owner_id": 17189275,
       "icon": "apollo.svg",
       "created_at": "2016-04-21T09:26:01.000Z",
-      "url": "https://www.apollographql.com/docs/apollo-server/",
-      "slug": "apollo-server"
+      "url": "https://www.apollographql.com/docs/apollo-server/"
     },
     {
       "name": "Imba",
+      "slug": "imba",
       "full_name": "imba/imba",
       "description": "The friendly full-stack language",
       "stars": 5453,
@@ -1880,11 +1885,11 @@
       "owner_id": 45297010,
       "icon": "imba.svg",
       "created_at": "2014-06-14T18:58:32.000Z",
-      "url": "https://imba.io",
-      "slug": "imba"
+      "url": "https://imba.io"
     },
     {
       "name": "Vendure",
+      "slug": "vendure",
       "full_name": "vendure-ecommerce/vendure",
       "description": "A headless GraphQL ecommerce framework for the modern web",
       "stars": 3036,
@@ -1893,11 +1898,11 @@
       "tags": ["graphql", "ecommerce"],
       "owner_id": 39629390,
       "created_at": "2018-06-11T14:29:20.000Z",
-      "url": "https://www.vendure.io",
-      "slug": "vendure"
+      "url": "https://www.vendure.io"
     },
     {
       "name": "wmr",
+      "slug": "wmr",
       "full_name": "preactjs/wmr",
       "description": "The tiny all-in-one development tool for modern web apps.",
       "stars": 4403,
@@ -1906,11 +1911,11 @@
       "tags": ["build", "prefetch"],
       "owner_id": 26872990,
       "created_at": "2020-05-21T22:19:03.000Z",
-      "url": "https://wmr.dev/",
-      "slug": "wmr"
+      "url": "https://wmr.dev/"
     },
     {
       "name": "Qwik",
+      "slug": "qwik",
       "full_name": "BuilderIO/qwik",
       "description": "An Open-Source framework designed for best possible time to interactive, by focusing on resumability of server-side-rendering of HTML, and fine-grained lazy-loading of code.",
       "stars": 1349,
@@ -1919,10 +1924,11 @@
       "tags": ["nodejs-framework", "universal"],
       "owner_id": 35700027,
       "created_at": "2021-05-19T15:33:32.000Z",
-      "slug": "qwik"
+      "icon": "qwik.svg"
     },
     {
       "name": "Stimulus",
+      "slug": "stimulus",
       "full_name": "hotwired/stimulus",
       "description": "A modest JavaScript framework for the HTML you already have",
       "stars": 11082,
@@ -1932,11 +1938,11 @@
       "owner_id": 75388917,
       "icon": "stimulus.svg",
       "created_at": "2016-12-17T00:19:29.000Z",
-      "url": "https://stimulus.hotwired.dev/",
-      "slug": "stimulus"
+      "url": "https://stimulus.hotwired.dev/"
     },
     {
       "name": "Relay",
+      "slug": "relay",
       "full_name": "facebook/relay",
       "description": "Relay is a JavaScript framework for building data-driven React applications.",
       "stars": 16529,
@@ -1946,11 +1952,11 @@
       "owner_id": 69631,
       "icon": "relay.svg",
       "created_at": "2015-08-10T22:09:16.000Z",
-      "url": "https://relay.dev",
-      "slug": "relay"
+      "url": "https://relay.dev"
     },
     {
       "name": "NativeScript",
+      "slug": "nativescript",
       "full_name": "NativeScript/NativeScript",
       "description": "NativeScript empowers you to access native platform APIs from JavaScript directly. Angular, Capacitor, Ionic, React, Svelte, Vue and you name it compatible.",
       "stars": 20788,
@@ -1960,11 +1966,11 @@
       "owner_id": 7392261,
       "icon": "nativescript.svg",
       "created_at": "2015-03-01T09:47:08.000Z",
-      "url": "https://nativescript.org",
-      "slug": "nativescript"
+      "url": "https://nativescript.org"
     },
     {
       "name": "Stencil",
+      "slug": "stencil",
       "full_name": "ionic-team/stencil",
       "description": "A toolchain for building scalable, enterprise-ready component systems on top of TypeScript and Web Component standards. Stencil components can be distributed natively to React, Angular, Vue, and traditional web developers from a single, framework-agnostic codebase.",
       "stars": 9949,
@@ -1974,11 +1980,11 @@
       "owner_id": 3171503,
       "icon": "stencil.svg",
       "created_at": "2017-02-15T18:57:07.000Z",
-      "url": "https://stenciljs.com",
-      "slug": "stencil"
+      "url": "https://stenciljs.com"
     },
     {
       "name": "TypeGraphQL",
+      "slug": "typegraphql",
       "full_name": "MichalLytek/type-graphql",
       "description": "Create GraphQL schema and resolvers with TypeScript, using classes and decorators!",
       "stars": 6908,
@@ -1987,11 +1993,11 @@
       "tags": ["graphql", "nodejs-framework"],
       "owner_id": 10618781,
       "created_at": "2018-01-09T15:58:38.000Z",
-      "url": "https://typegraphql.com",
-      "slug": "typegraphql"
+      "url": "https://typegraphql.com"
     },
     {
       "name": "CSS Modules",
+      "slug": "css-modules",
       "full_name": "css-modules/css-modules",
       "description": "Documentation about css-modules",
       "stars": 15631,
@@ -1999,11 +2005,11 @@
       "monthly": [55, 98, 78, 73, 103, 120, 98, 107, 84, 122, 83, 121],
       "tags": ["css-in-js"],
       "owner_id": 12612655,
-      "created_at": "2015-05-25T21:54:47.000Z",
-      "slug": "css-modules"
+      "created_at": "2015-05-25T21:54:47.000Z"
     },
     {
       "name": "React NodeGUI",
+      "slug": "react-nodegui",
       "full_name": "nodegui/react-nodegui",
       "description": "Build performant, native and cross-platform desktop applications with native React + powerful CSS like styling.",
       "stars": 5933,
@@ -2013,11 +2019,11 @@
       "owner_id": 51644128,
       "icon": "nodegui.svg",
       "created_at": "2019-06-23T20:41:01.000Z",
-      "url": "https://react.nodegui.org",
-      "slug": "react-nodegui"
+      "url": "https://react.nodegui.org"
     },
     {
       "name": "NW.js",
+      "slug": "nwjs",
       "full_name": "nwjs/nw.js",
       "description": "Call all Node.js modules directly from DOM/WebWorker and enable a new way of writing applications with all Web technologies.",
       "stars": 38668,
@@ -2027,11 +2033,11 @@
       "owner_id": 10180421,
       "icon": "nw.svg",
       "created_at": "2012-01-04T06:21:10.000Z",
-      "url": "https://nwjs.io",
-      "slug": "nwjs"
+      "url": "https://nwjs.io"
     },
     {
       "name": "Radi",
+      "slug": "radi",
       "full_name": "Marcisbee/radi",
       "description": "Tiny (in size) front-end framework with no extra browser re-flows",
       "stars": 950,
@@ -2040,11 +2046,11 @@
       "tags": ["framework"],
       "owner_id": 16621507,
       "created_at": "2018-01-09T17:29:23.000Z",
-      "url": "https://radi.js.org",
-      "slug": "radi"
+      "url": "https://radi.js.org"
     },
     {
       "name": "Marko",
+      "slug": "marko",
       "full_name": "marko-js/marko",
       "description": "A declarative, HTML-based language that makes building web apps fun",
       "stars": 10835,
@@ -2054,11 +2060,11 @@
       "owner_id": 11873696,
       "icon": "marko.svg",
       "created_at": "2014-01-07T23:58:21.000Z",
-      "url": "https://markojs.com/",
-      "slug": "marko"
+      "url": "https://markojs.com/"
     },
     {
       "name": "Gridsome",
+      "slug": "gridsome",
       "full_name": "gridsome/gridsome",
       "description": "The Jamstack framework for Vue.js",
       "stars": 8044,
@@ -2067,11 +2073,11 @@
       "tags": ["ssg", "vue", "graphql"],
       "owner_id": 17981963,
       "created_at": "2018-07-31T22:55:06.000Z",
-      "url": "https://gridsome.org",
-      "slug": "gridsome"
+      "url": "https://gridsome.org"
     },
     {
       "name": "Neo.mjs",
+      "slug": "neomjs",
       "full_name": "neomjs/neo",
       "description": "The webworkers driven UI framework",
       "stars": 2059,
@@ -2080,11 +2086,11 @@
       "tags": ["framework", "webworker"],
       "owner_id": 55371235,
       "created_at": "2019-11-10T23:56:02.000Z",
-      "url": "https://neomjs.github.io/pages/",
-      "slug": "neomjs"
+      "url": "https://neomjs.github.io/pages/"
     },
     {
       "name": "Ant Design Mobile",
+      "slug": "ant-design-mobile",
       "full_name": "ant-design/ant-design-mobile",
       "description": "Fluent and powerful mobile component library based on React.",
       "stars": 9532,
@@ -2094,11 +2100,11 @@
       "owner_id": 12101536,
       "icon": "ant.svg",
       "created_at": "2015-11-30T03:33:06.000Z",
-      "url": "https://mobile.ant.design",
-      "slug": "ant-design-mobile"
+      "url": "https://mobile.ant.design"
     },
     {
       "name": "Styled JSX",
+      "slug": "styled-jsx",
       "full_name": "vercel/styled-jsx",
       "description": "Full CSS support for JSX without compromises",
       "stars": 6805,
@@ -2106,11 +2112,11 @@
       "monthly": [61, 58, 55, 78, 137, 62, 39, 53, 56, 127, 54, 54],
       "tags": ["css-in-js"],
       "owner_id": 14985020,
-      "created_at": "2016-12-05T13:58:02.000Z",
-      "slug": "styled-jsx"
+      "created_at": "2016-12-05T13:58:02.000Z"
     },
     {
       "name": "Nano stores",
+      "slug": "nano-stores",
       "full_name": "nanostores/nanostores",
       "description": "A tiny (199 bytes) state manager for React/RN/Preact/Vue/Svelte with many atomic tree-shakable stores",
       "stars": 1167,
@@ -2118,11 +2124,11 @@
       "monthly": [76, 59, 84, 66, 69, 107, 368, null, null, null, null, null],
       "tags": ["state"],
       "owner_id": 85066968,
-      "created_at": "2020-10-14T19:51:28.000Z",
-      "slug": "nano-stores"
+      "created_at": "2020-10-14T19:51:28.000Z"
     },
     {
       "name": "AMP",
+      "slug": "amp",
       "full_name": "ampproject/amphtml",
       "description": "The AMP web component framework.",
       "stars": 14781,
@@ -2132,11 +2138,11 @@
       "owner_id": 14114390,
       "icon": "amp.svg",
       "created_at": "2015-09-01T22:10:53.000Z",
-      "url": "https://amp.dev",
-      "slug": "amp"
+      "url": "https://amp.dev"
     },
     {
       "name": "Goober",
+      "slug": "goober",
       "full_name": "cristianbote/goober",
       "description": "A less than 1KB css-in-js alternative with a familiar API",
       "stars": 2344,
@@ -2145,11 +2151,11 @@
       "tags": ["css-in-js"],
       "owner_id": 3405161,
       "created_at": "2019-01-31T11:14:38.000Z",
-      "url": "https://goober.rocks",
-      "slug": "goober"
+      "url": "https://goober.rocks"
     },
     {
       "name": "Vue Native",
+      "slug": "vue-native",
       "full_name": "GeekyAnts/vue-native-core",
       "description": "Vue Native is a framework to build cross platform native mobile apps using JavaScript",
       "stars": 8368,
@@ -2158,11 +2164,11 @@
       "tags": ["mobile", "vue"],
       "owner_id": 18482943,
       "created_at": "2018-02-23T11:44:30.000Z",
-      "url": "https://vue-native.io",
-      "slug": "vue-native"
+      "url": "https://vue-native.io"
     },
     {
       "name": "Framework7",
+      "slug": "framework7",
       "full_name": "framework7io/framework7",
       "description": "Full featured HTML framework for building iOS & Android apps",
       "stars": 16585,
@@ -2171,11 +2177,11 @@
       "tags": ["mobile"],
       "owner_id": 31954178,
       "created_at": "2014-02-23T12:15:53.000Z",
-      "url": "http://framework7.io",
-      "slug": "framework7"
+      "url": "http://framework7.io"
     },
     {
       "name": "Angular Electron",
+      "slug": "angular-electron",
       "full_name": "maximegris/angular-electron",
       "description": "Ultra-fast bootstrapping with Angular and Electron (Typescript + SASS + Hot Reload)",
       "stars": 4934,
@@ -2183,11 +2189,11 @@
       "monthly": [23, 38, 24, 40, 50, 64, 69, 46, 74, 50, 71, 83],
       "tags": ["desktop", "angular"],
       "owner_id": 10827551,
-      "created_at": "2017-04-02T11:15:28.000Z",
-      "slug": "angular-electron"
+      "created_at": "2017-04-02T11:15:28.000Z"
     },
     {
       "name": "Mithril",
+      "slug": "mithril",
       "full_name": "MithrilJS/mithril.js",
       "description": "A JavaScript Framework for Building Brilliant Applications",
       "stars": 13090,
@@ -2197,8 +2203,7 @@
       "owner_id": 19475707,
       "icon": "mithril.svg",
       "created_at": "2014-03-17T01:59:39.000Z",
-      "url": "https://mithril.js.org",
-      "slug": "mithril"
+      "url": "https://mithril.js.org"
     }
   ],
   "tags": [

--- a/data/2022/projects.json
+++ b/data/2022/projects.json
@@ -3,6 +3,7 @@
   "projects": [
     {
       "name": "Bun",
+      "slug": "bun",
       "full_name": "oven-sh/bun",
       "description": "Incredibly fast JavaScript runtime, bundler, transpiler and package manager – all in one.",
       "stars": 37388,
@@ -14,11 +15,11 @@
       "owner_id": 108928776,
       "icon": "bun.svg",
       "created_at": "2021-04-14T00:48:17.000Z",
-      "url": "https://bun.sh",
-      "slug": "bun"
+      "url": "https://bun.sh"
     },
     {
       "name": "Tauri",
+      "slug": "tauri",
       "full_name": "tauri-apps/tauri",
       "description": "Build smaller, faster, and more secure desktop applications with a web frontend.",
       "stars": 56643,
@@ -30,11 +31,11 @@
       "owner_id": 54536011,
       "icon": "tauri.svg",
       "created_at": "2019-07-13T09:09:37.000Z",
-      "url": "https://tauri.app",
-      "slug": "tauri"
+      "url": "https://tauri.app"
     },
     {
       "name": "React",
+      "slug": "react",
       "full_name": "facebook/react",
       "description": "A declarative, efficient, and flexible JavaScript library for building user interfaces.",
       "stars": 200171,
@@ -46,11 +47,11 @@
       "owner_id": 69631,
       "icon": "react.svg",
       "created_at": "2013-05-24T16:15:54.000Z",
-      "url": "https://reactjs.org",
-      "slug": "react"
+      "url": "https://reactjs.org"
     },
     {
       "name": "Next.js",
+      "slug": "nextjs",
       "full_name": "vercel/next.js",
       "description": "The React Framework",
       "stars": 98772,
@@ -69,11 +70,11 @@
       "owner_id": 14985020,
       "icon": "nextjs.svg",
       "created_at": "2016-10-05T23:32:51.000Z",
-      "url": "https://nextjs.org",
-      "slug": "nextjs"
+      "url": "https://nextjs.org"
     },
     {
       "name": "Vite",
+      "slug": "vite",
       "full_name": "vitejs/vite",
       "description": "Next generation frontend tooling. It's fast!",
       "stars": 51266,
@@ -85,11 +86,11 @@
       "owner_id": 65625612,
       "icon": "vite.svg",
       "created_at": "2020-04-21T05:03:57.000Z",
-      "url": "http://vitejs.dev",
-      "slug": "vite"
+      "url": "http://vitejs.dev"
     },
     {
       "name": "tRPC",
+      "slug": "trpc",
       "full_name": "trpc/trpc",
       "description": "Move Fast and Break Nothing. End-to-end typesafe APIs made easy.",
       "stars": 18408,
@@ -108,11 +109,11 @@
       "owner_id": 78011399,
       "icon": "trpc.svg",
       "created_at": "2020-07-18T01:17:11.000Z",
-      "url": "https://tRPC.io",
-      "slug": "trpc"
+      "url": "https://tRPC.io"
     },
     {
       "name": "Astro",
+      "slug": "astro",
       "full_name": "withastro/astro",
       "description": "A website build tool for the modern web — powerful developer experience meets lightweight output.",
       "stars": 24251,
@@ -124,11 +125,11 @@
       "owner_id": 44914786,
       "icon": "astro.svg",
       "created_at": "2021-03-15T17:19:47.000Z",
-      "url": "https://astro.build",
-      "slug": "astro"
+      "url": "https://astro.build"
     },
     {
       "name": "VS Code",
+      "slug": "vs-code",
       "full_name": "microsoft/vscode",
       "description": "Visual Studio Code",
       "stars": 141104,
@@ -140,11 +141,11 @@
       "owner_id": 6154722,
       "icon": "vscode.svg",
       "created_at": "2015-09-03T20:23:38.000Z",
-      "url": "https://code.visualstudio.com",
-      "slug": "vs-code"
+      "url": "https://code.visualstudio.com"
     },
     {
       "name": "Tabby",
+      "slug": "tabby",
       "full_name": "Eugeny/tabby",
       "description": "A terminal for a more modern age",
       "stars": 42143,
@@ -156,11 +157,11 @@
       "owner_id": 161476,
       "icon": "tabby.svg",
       "created_at": "2016-12-23T09:06:10.000Z",
-      "url": "https://tabby.sh",
-      "slug": "tabby"
+      "url": "https://tabby.sh"
     },
     {
       "name": "Playwright",
+      "slug": "playwright",
       "full_name": "microsoft/playwright",
       "description": "A framework for Web Testing and Automation. It allows testing Chromium, Firefox and WebKit with a single API.",
       "stars": 46323,
@@ -172,11 +173,11 @@
       "owner_id": 6154722,
       "icon": "playwright.svg",
       "created_at": "2019-11-15T18:32:42.000Z",
-      "url": "https://playwright.dev",
-      "slug": "playwright"
+      "url": "https://playwright.dev"
     },
     {
       "name": "Turborepo",
+      "slug": "turborepo",
       "full_name": "vercel/turbo",
       "description": "Incremental bundler and build system optimized for JavaScript and TypeScript, written in Rust – including Turbopack and Turborepo.",
       "stars": 18569,
@@ -188,11 +189,11 @@
       "owner_id": 14985020,
       "icon": "turborepo.svg",
       "created_at": "2021-10-05T17:37:11.000Z",
-      "url": "https://turbo.build",
-      "slug": "turborepo"
+      "url": "https://turbo.build"
     },
     {
       "name": "Mermaid",
+      "slug": "mermaid",
       "full_name": "mermaid-js/mermaid",
       "description": "Generation of diagrams like flowcharts or sequence diagrams from text in a similar manner as markdown",
       "stars": 52808,
@@ -203,11 +204,11 @@
       "tags": ["chart", "d3", "diagram"],
       "owner_id": 57169982,
       "created_at": "2014-11-01T23:52:32.000Z",
-      "url": "http://mermaid.js.org",
-      "slug": "mermaid"
+      "url": "http://mermaid.js.org"
     },
     {
       "name": "Mantine",
+      "slug": "mantine",
       "full_name": "mantinedev/mantine",
       "description": "React components library with native dark theme support",
       "stars": 16626,
@@ -219,11 +220,11 @@
       "owner_id": 79146003,
       "icon": "mantine.svg",
       "created_at": "2021-01-07T14:02:19.000Z",
-      "url": "https://mantine.dev",
-      "slug": "mantine"
+      "url": "https://mantine.dev"
     },
     {
       "name": "Qwik",
+      "slug": "qwik",
       "full_name": "BuilderIO/qwik",
       "description": "The HTML-first framework. Instant apps of any size with ~ 1kb JS",
       "stars": 14316,
@@ -233,11 +234,11 @@
       "owner_id": 35700027,
       "icon": "qwik.svg",
       "created_at": "2021-05-19T15:33:32.000Z",
-      "url": "https://qwik.builder.io/",
-      "slug": "qwik"
+      "url": "https://qwik.builder.io/"
     },
     {
       "name": "Excalidraw",
+      "slug": "excalidraw",
       "full_name": "excalidraw/excalidraw",
       "description": "Virtual whiteboard for sketching hand-drawn like diagrams",
       "stars": 39048,
@@ -249,10 +250,11 @@
       "owner_id": 59452120,
       "created_at": "2020-01-02T01:04:43.000Z",
       "url": "https://excalidraw.com",
-      "slug": "excalidraw"
+      "icon": "excalidraw.svg"
     },
     {
       "name": "Zustand",
+      "slug": "zustand",
       "full_name": "pmndrs/zustand",
       "description": "Bear necessities for state management in React",
       "stars": 25466,
@@ -264,10 +266,11 @@
       "owner_id": 45790596,
       "created_at": "2019-04-09T09:10:06.000Z",
       "url": "https://zustand-demo.pmnd.rs/",
-      "slug": "zustand"
+      "icon": "zustand.webp"
     },
     {
       "name": "create-t3-app",
+      "slug": "create-t3-app",
       "full_name": "t3-oss/create-t3-app",
       "description": "The best way to start a full-stack, typesafe Next.js app",
       "stars": 12737,
@@ -296,11 +299,11 @@
       ],
       "owner_id": 108266839,
       "created_at": "2022-05-24T13:31:01.000Z",
-      "url": "https://create.t3.gg",
-      "slug": "create-t3-app"
+      "url": "https://create.t3.gg"
     },
     {
       "name": "NocoDB",
+      "slug": "nocodb",
       "full_name": "nocodb/nocodb",
       "description": "Open Source Airtable Alternative",
       "stars": 33429,
@@ -312,10 +315,11 @@
       "owner_id": 50206778,
       "created_at": "2017-10-29T18:51:48.000Z",
       "url": "https://nocodb.com",
-      "slug": "nocodb"
+      "icon": "nocodb.svg"
     },
     {
       "name": "Mark Text",
+      "slug": "mark-text",
       "full_name": "marktext/marktext",
       "description": "A simple and elegant markdown editor, available for Linux, macOS and Windows.",
       "stars": 37826,
@@ -326,11 +330,11 @@
       "tags": ["md", "md-editor-app"],
       "owner_id": 36623013,
       "created_at": "2017-11-12T16:05:25.000Z",
-      "url": "https://marktext.app",
-      "slug": "mark-text"
+      "url": "https://marktext.app"
     },
     {
       "name": "Tailwind CSS",
+      "slug": "tailwind-css",
       "full_name": "tailwindlabs/tailwindcss",
       "description": "A utility-first CSS framework for rapid UI development.",
       "stars": 63868,
@@ -342,11 +346,11 @@
       "owner_id": 67109815,
       "icon": "tailwindcss.svg",
       "created_at": "2017-10-06T14:59:14.000Z",
-      "url": "https://tailwindcss.com/",
-      "slug": "tailwind-css"
+      "url": "https://tailwindcss.com/"
     },
     {
       "name": "Docusaurus",
+      "slug": "docusaurus",
       "full_name": "facebook/docusaurus",
       "description": "Easy to maintain open source documentation websites.",
       "stars": 40960,
@@ -356,11 +360,11 @@
       "owner_id": 69631,
       "icon": "docusaurus.svg",
       "created_at": "2017-06-20T16:13:53.000Z",
-      "url": "https://docusaurus.io",
-      "slug": "docusaurus"
+      "url": "https://docusaurus.io"
     },
     {
       "name": "Remix",
+      "slug": "remix",
       "full_name": "remix-run/remix",
       "description": "Build Better Websites. Create modern, resilient user experiences with web fundamentals.",
       "stars": 21505,
@@ -372,11 +376,11 @@
       "owner_id": 64235328,
       "icon": "remix.svg",
       "created_at": "2020-10-26T19:57:28.000Z",
-      "url": "https://remix.run",
-      "slug": "remix"
+      "url": "https://remix.run"
     },
     {
       "name": "zx",
+      "slug": "zx",
       "full_name": "google/zx",
       "description": "A tool for writing better scripts",
       "stars": 35724,
@@ -387,10 +391,11 @@
       "tags": ["cli"],
       "owner_id": 1342004,
       "created_at": "2021-05-05T05:50:01.000Z",
-      "slug": "zx"
+      "icon": "zx.svg"
     },
     {
       "name": "Solid",
+      "slug": "solid",
       "full_name": "solidjs/solid",
       "description": "A declarative, efficient, and flexible JavaScript library for building user interfaces.",
       "stars": 24572,
@@ -402,11 +407,11 @@
       "owner_id": 79226042,
       "icon": "solid.svg",
       "created_at": "2018-04-24T16:36:27.000Z",
-      "url": "https://solidjs.com",
-      "slug": "solid"
+      "url": "https://solidjs.com"
     },
     {
       "name": "Zod",
+      "slug": "zod",
       "full_name": "colinhacks/zod",
       "description": "TypeScript-first schema validation with static type inference",
       "stars": 16620,
@@ -418,11 +423,11 @@
       "owner_id": 3084745,
       "icon": "zod.svg",
       "created_at": "2020-03-07T20:59:08.000Z",
-      "url": "https://zod.dev",
-      "slug": "zod"
+      "url": "https://zod.dev"
     },
     {
       "name": "Three.js",
+      "slug": "threejs",
       "full_name": "mrdoob/three.js",
       "description": "JavaScript 3D Library.",
       "stars": 88042,
@@ -432,11 +437,11 @@
       "owner_id": 97088,
       "icon": "threejs.svg",
       "created_at": "2010-03-23T18:58:01.000Z",
-      "url": "https://threejs.org/",
-      "slug": "threejs"
+      "url": "https://threejs.org/"
     },
     {
       "name": "Medusa",
+      "slug": "medusa",
       "full_name": "medusajs/medusa",
       "description": "The open-source Shopify alternative",
       "stars": 16117,
@@ -445,11 +450,11 @@
       "tags": ["ecommerce"],
       "owner_id": 62591822,
       "created_at": "2020-01-18T13:39:04.000Z",
-      "url": "https://medusajs.com",
-      "slug": "medusa"
+      "url": "https://medusajs.com"
     },
     {
       "name": "TypeScript",
+      "slug": "typescript",
       "full_name": "microsoft/TypeScript",
       "description": "A superset of JavaScript that compiles to clean JavaScript output.",
       "stars": 87388,
@@ -459,11 +464,11 @@
       "owner_id": 6154722,
       "icon": "typescript.svg",
       "created_at": "2014-06-17T15:28:39.000Z",
-      "url": "https://www.typescriptlang.org",
-      "slug": "typescript"
+      "url": "https://www.typescriptlang.org"
     },
     {
       "name": "Svelte",
+      "slug": "svelte",
       "full_name": "sveltejs/svelte",
       "description": "Cybernetically enhanced web apps",
       "stars": 64568,
@@ -475,11 +480,11 @@
       "owner_id": 23617963,
       "icon": "svelte.svg",
       "created_at": "2016-11-20T18:13:05.000Z",
-      "url": "https://svelte.dev",
-      "slug": "svelte"
+      "url": "https://svelte.dev"
     },
     {
       "name": "Nest",
+      "slug": "nest",
       "full_name": "nestjs/nest",
       "description": "A progressive Node.js framework for building efficient, scalable, and enterprise-grade server-side applications on top of TypeScript & JavaScript (ES6, ES7, ES8)",
       "stars": 53395,
@@ -489,11 +494,11 @@
       "owner_id": 28507035,
       "icon": "nest.svg",
       "created_at": "2017-02-04T20:12:52.000Z",
-      "url": "https://nestjs.com",
-      "slug": "nest"
+      "url": "https://nestjs.com"
     },
     {
       "name": "Vue.js 2",
+      "slug": "vuejs-2",
       "full_name": "vuejs/vue",
       "description": "A progressive, incrementally-adoptable framework for building UI on the web",
       "stars": 201655,
@@ -503,11 +508,11 @@
       "owner_id": 6128107,
       "icon": "vue.svg",
       "created_at": "2013-07-29T03:24:51.000Z",
-      "url": "http://v2.vuejs.org",
-      "slug": "vuejs-2"
+      "url": "http://v2.vuejs.org"
     },
     {
       "name": "Material UI",
+      "slug": "material-ui",
       "full_name": "mui/material-ui",
       "description": " A robust, customizable, and accessible library of foundational and advanced components, enabling you to build your own design system and develop React applications faster",
       "stars": 83770,
@@ -517,11 +522,11 @@
       "owner_id": 33663932,
       "icon": "material-ui.svg",
       "created_at": "2014-08-18T19:11:54.000Z",
-      "url": "https://mui.com/core/",
-      "slug": "material-ui"
+      "url": "https://mui.com/core/"
     },
     {
       "name": "DaisyUI",
+      "slug": "daisyui",
       "full_name": "saadeghi/daisyui",
       "description": "Component classes to Tailwind CSS",
       "stars": 16817,
@@ -531,10 +536,11 @@
       "owner_id": 7342023,
       "created_at": "2020-11-28T22:57:27.000Z",
       "url": "https://daisyui.com",
-      "slug": "daisyui"
+      "icon": "daisy.svg"
     },
     {
       "name": "nvm",
+      "slug": "nvm",
       "full_name": "nvm-sh/nvm",
       "description": "Node Version Manager - POSIX-compliant bash script to manage multiple active node.js versions",
       "stars": 63817,
@@ -542,11 +548,11 @@
       "monthly": [697, 866, 838, 652, 718, 867, 785, 774, 874, 809, 696, 790],
       "tags": ["nvm"],
       "owner_id": 49963700,
-      "created_at": "2010-04-15T17:47:47.000Z",
-      "slug": "nvm"
+      "created_at": "2010-04-15T17:47:47.000Z"
     },
     {
       "name": "Fresh",
+      "slug": "fresh",
       "full_name": "denoland/fresh",
       "description": "The next-gen web framework.",
       "stars": 9735,
@@ -556,11 +562,11 @@
       "owner_id": 42048915,
       "icon": "fresh.svg",
       "created_at": "2021-05-07T14:42:26.000Z",
-      "url": "https://fresh.deno.dev",
-      "slug": "fresh"
+      "url": "https://fresh.deno.dev"
     },
     {
       "name": "Strapi",
+      "slug": "strapi",
       "full_name": "strapi/strapi",
       "description": "The leading open-source headless CMS. It’s 100% JavaScript, fully customizable and developer-first.",
       "stars": 51053,
@@ -570,11 +576,11 @@
       "owner_id": 19872173,
       "icon": "strapi.svg",
       "created_at": "2015-09-30T15:34:48.000Z",
-      "url": "https://strapi.io",
-      "slug": "strapi"
+      "url": "https://strapi.io"
     },
     {
       "name": "Prisma",
+      "slug": "prisma",
       "full_name": "prisma/prisma",
       "description": "Next-generation ORM for Node.js & TypeScript | PostgreSQL, MySQL, MariaDB, SQL Server, SQLite, MongoDB and CockroachDB",
       "stars": 28169,
@@ -584,11 +590,11 @@
       "owner_id": 17219288,
       "icon": "prisma.svg",
       "created_at": "2019-06-20T13:33:47.000Z",
-      "url": "https://www.prisma.io",
-      "slug": "prisma"
+      "url": "https://www.prisma.io"
     },
     {
       "name": "Node.js",
+      "slug": "nodejs",
       "full_name": "nodejs/node",
       "description": "Node.js JavaScript runtime",
       "stars": 92534,
@@ -598,11 +604,11 @@
       "owner_id": 9950313,
       "icon": "nodejs.svg",
       "created_at": "2014-11-26T19:57:11.000Z",
-      "url": "https://nodejs.org",
-      "slug": "nodejs"
+      "url": "https://nodejs.org"
     },
     {
       "name": "Faker",
+      "slug": "faker",
       "full_name": "faker-js/faker",
       "description": "Generate massive amounts of fake data in the browser and node.js",
       "stars": 8415,
@@ -611,11 +617,11 @@
       "tags": ["random"],
       "owner_id": 97165289,
       "created_at": "2022-01-07T17:22:27.000Z",
-      "url": "https://fakerjs.dev",
-      "slug": "faker"
+      "url": "https://fakerjs.dev"
     },
     {
       "name": "Storybook",
+      "slug": "storybook",
       "full_name": "storybookjs/storybook",
       "description": "A frontend workshop for building UI components and pages in isolation. Made for UI development, testing, and documentation.",
       "stars": 75877,
@@ -625,8 +631,7 @@
       "owner_id": 22632046,
       "icon": "storybook.svg",
       "created_at": "2016-03-18T04:23:44.000Z",
-      "url": "https://storybook.js.org",
-      "slug": "storybook"
+      "url": "https://storybook.js.org"
     },
     {
       "name": "Vue.js 3",
@@ -644,6 +649,7 @@
     },
     {
       "name": "n8n",
+      "slug": "n8n",
       "full_name": "n8n-io/n8n",
       "description": "Free and source-available fair-code licensed workflow automation tool. Easily automate tasks across different services.",
       "stars": 27443,
@@ -653,10 +659,11 @@
       "owner_id": 45487711,
       "created_at": "2019-06-22T09:24:21.000Z",
       "url": "https://n8n.io",
-      "slug": "n8n"
+      "icon": "n8n.svg"
     },
     {
       "name": "Tabler",
+      "slug": "tabler",
       "full_name": "tabler/tabler",
       "description": "Free and open-source HTML Dashboard UI Kit built on Bootstrap 4",
       "stars": 32556,
@@ -665,11 +672,11 @@
       "tags": ["html", "dashboard", "bootstrap"],
       "owner_id": 35471246,
       "created_at": "2018-02-01T09:08:59.000Z",
-      "url": "https://preview.tabler.io",
-      "slug": "tabler"
+      "url": "https://preview.tabler.io"
     },
     {
       "name": "Axios",
+      "slug": "axios",
       "full_name": "axios/axios",
       "description": "Promise based HTTP client for the browser and node.js",
       "stars": 98079,
@@ -679,11 +686,11 @@
       "owner_id": 32372333,
       "icon": "axios.svg",
       "created_at": "2014-08-18T22:30:27.000Z",
-      "url": "https://axios-http.com",
-      "slug": "axios"
+      "url": "https://axios-http.com"
     },
     {
       "name": "react-use",
+      "slug": "react-use",
       "full_name": "streamich/react-use",
       "description": "Collection of essential React Hooks",
       "stars": 34940,
@@ -692,11 +699,11 @@
       "tags": ["react", "hook"],
       "owner_id": 9773803,
       "created_at": "2018-10-27T10:16:05.000Z",
-      "url": "http://streamich.github.io/react-use",
-      "slug": "react-use"
+      "url": "http://streamich.github.io/react-use"
     },
     {
       "name": "Partytown",
+      "slug": "partytown",
       "full_name": "BuilderIO/partytown",
       "description": "Relocate resource intensive third-party scripts off of the main thread and into a web worker.",
       "stars": 10535,
@@ -704,11 +711,11 @@
       "monthly": [464, 219, 241, 327, 344, 295, 440, 403, 934, 2835, 769, 316],
       "tags": ["webworker"],
       "owner_id": 35700027,
-      "created_at": "2021-08-20T17:12:55.000Z",
-      "slug": "partytown"
+      "created_at": "2021-08-20T17:12:55.000Z"
     },
     {
       "name": "Deno",
+      "slug": "deno",
       "full_name": "denoland/deno",
       "description": "A modern runtime for JavaScript and TypeScript.",
       "stars": 87133,
@@ -718,11 +725,11 @@
       "owner_id": 42048915,
       "icon": "deno.svg",
       "created_at": "2018-05-15T01:34:26.000Z",
-      "url": "https://deno.land",
-      "slug": "deno"
+      "url": "https://deno.land"
     },
     {
       "name": "Chakra UI",
+      "slug": "chakra-ui",
       "full_name": "chakra-ui/chakra-ui",
       "description": "Simple, Modular & Accessible UI Components for your React Applications",
       "stars": 30558,
@@ -732,11 +739,11 @@
       "owner_id": 54212428,
       "icon": "chakra-ui.svg",
       "created_at": "2019-08-17T14:27:54.000Z",
-      "url": "https://chakra-ui.com",
-      "slug": "chakra-ui"
+      "url": "https://chakra-ui.com"
     },
     {
       "name": "React Hook Form",
+      "slug": "react-hook-form",
       "full_name": "react-hook-form/react-hook-form",
       "description": "React Hooks for form state management and validation (Web + React Native)",
       "stars": 32568,
@@ -746,11 +753,11 @@
       "owner_id": 53986236,
       "icon": "react-hook-form.svg",
       "created_at": "2019-03-05T23:47:10.000Z",
-      "url": "https://react-hook-form.com",
-      "slug": "react-hook-form"
+      "url": "https://react-hook-form.com"
     },
     {
       "name": "TanStack Query",
+      "slug": "tanstack-query",
       "full_name": "TanStack/query",
       "description": "Powerful asynchronous state management, server-state utilities and data fetching for the web. TS/JS, React Query, Solid Query, Svelte Query and Vue Query.",
       "stars": 32100,
@@ -759,11 +766,11 @@
       "tags": ["data", "graphql", "caching", "react", "vue", "solid", "svelte"],
       "owner_id": 72518640,
       "created_at": "2019-09-10T19:23:58.000Z",
-      "url": "https://tanstack.com/query",
-      "slug": "tanstack-query"
+      "url": "https://tanstack.com/query"
     },
     {
       "name": "Slidev",
+      "slug": "slidev",
       "full_name": "slidevjs/slidev",
       "description": "Presentation Slides for Developers",
       "stars": 24250,
@@ -773,11 +780,11 @@
       "owner_id": 83095831,
       "icon": "slidev.svg",
       "created_at": "2021-04-24T01:25:23.000Z",
-      "url": "https://sli.dev",
-      "slug": "slidev"
+      "url": "https://sli.dev"
     },
     {
       "name": "Angular",
+      "slug": "angular",
       "full_name": "angular/angular",
       "description": "The modern web developer’s platform",
       "stars": 85771,
@@ -787,11 +794,11 @@
       "owner_id": 139426,
       "icon": "angular.svg",
       "created_at": "2014-09-18T16:12:01.000Z",
-      "url": "https://angular.io",
-      "slug": "angular"
+      "url": "https://angular.io"
     },
     {
       "name": "Nuxt 3",
+      "slug": "nuxt-3",
       "full_name": "nuxt/framework",
       "description": "The Intuitive Web Framework, based on Vue 3.",
       "stars": 11118,
@@ -801,11 +808,11 @@
       "owner_id": 23360933,
       "icon": "nuxt.svg",
       "created_at": "2021-03-17T19:07:24.000Z",
-      "url": "https://nuxt.com",
-      "slug": "nuxt-3"
+      "url": "https://nuxt.com"
     },
     {
       "name": "Ant Design",
+      "slug": "ant-design",
       "full_name": "ant-design/ant-design",
       "description": "An enterprise-class UI design language and React UI library",
       "stars": 83691,
@@ -815,11 +822,11 @@
       "owner_id": 12101536,
       "icon": "ant.svg",
       "created_at": "2015-04-24T15:37:24.000Z",
-      "url": "https://ant.design",
-      "slug": "ant-design"
+      "url": "https://ant.design"
     },
     {
       "name": "Cypress",
+      "slug": "cypress",
       "full_name": "cypress-io/cypress",
       "description": "Fast, easy and reliable testing for anything that runs in a browser.",
       "stars": 42249,
@@ -829,11 +836,11 @@
       "owner_id": 8908513,
       "icon": "cypress.svg",
       "created_at": "2015-03-04T00:46:28.000Z",
-      "url": "https://cypress.io",
-      "slug": "cypress"
+      "url": "https://cypress.io"
     },
     {
       "name": "Vue Element Admin",
+      "slug": "vue-element-admin",
       "full_name": "PanJiaChen/vue-element-admin",
       "description": "A magical vue admin",
       "stars": 80204,
@@ -842,11 +849,11 @@
       "tags": ["vue", "dashboard"],
       "owner_id": 8121621,
       "icon": "vueelementadmin.png",
-      "created_at": "2017-04-17T03:35:49.000Z",
-      "slug": "vue-element-admin"
+      "created_at": "2017-04-17T03:35:49.000Z"
     },
     {
       "name": "React Native",
+      "slug": "react-native",
       "full_name": "facebook/react-native",
       "description": "A framework for building native applications using React",
       "stars": 106880,
@@ -856,8 +863,7 @@
       "owner_id": 69631,
       "icon": "react-native.svg",
       "created_at": "2015-01-09T18:10:16.000Z",
-      "url": "https://reactnative.dev/",
-      "slug": "react-native"
+      "url": "https://reactnative.dev/"
     },
     {
       "name": "Serverless Stack",
@@ -874,6 +880,7 @@
     },
     {
       "name": "swc",
+      "slug": "swc",
       "full_name": "swc-project/swc",
       "description": "A super-fast compiler written in rust",
       "stars": 25472,
@@ -883,11 +890,11 @@
       "owner_id": 26715726,
       "icon": "swc.svg",
       "created_at": "2017-12-22T11:40:14.000Z",
-      "url": "https://swc.rs",
-      "slug": "swc"
+      "url": "https://swc.rs"
     },
     {
       "name": "AutoAnimate",
+      "slug": "autoanimate",
       "full_name": "formkit/auto-animate",
       "description": "A zero-config, drop-in animation utility that adds smooth transitions to your web app. You can use it with React, Vue, or any other JavaScript application.",
       "stars": 6495,
@@ -909,11 +916,11 @@
       "tags": ["animation", "react", "angular", "vue", "svelte"],
       "owner_id": 76744415,
       "created_at": "2022-05-11T18:50:01.000Z",
-      "url": "https://auto-animate.formkit.com",
-      "slug": "autoanimate"
+      "url": "https://auto-animate.formkit.com"
     },
     {
       "name": "SvelteKit",
+      "slug": "sveltekit",
       "full_name": "sveltejs/kit",
       "description": "web development, streamlined",
       "stars": 12488,
@@ -922,11 +929,11 @@
       "tags": ["svelte", "fullstack", "nodejs-framework", "vite"],
       "owner_id": 23617963,
       "created_at": "2020-10-15T14:00:23.000Z",
-      "url": "https://kit.svelte.dev",
-      "slug": "sveltekit"
+      "url": "https://kit.svelte.dev"
     },
     {
       "name": "Puppeteer",
+      "slug": "puppeteer",
       "full_name": "puppeteer/puppeteer",
       "description": "Headless Chrome Node.js API",
       "stars": 81443,
@@ -936,11 +943,11 @@
       "owner_id": 6906516,
       "icon": "puppeteer.svg",
       "created_at": "2017-05-09T22:16:13.000Z",
-      "url": "https://pptr.dev",
-      "slug": "puppeteer"
+      "url": "https://pptr.dev"
     },
     {
       "name": "Nx",
+      "slug": "nx",
       "full_name": "nrwl/nx",
       "description": "Smart, Fast and Extensible Build System",
       "stars": 15979,
@@ -950,11 +957,11 @@
       "owner_id": 23692104,
       "icon": "nx.svg",
       "created_at": "2017-08-11T18:50:23.000Z",
-      "url": "https://nx.dev",
-      "slug": "nx"
+      "url": "https://nx.dev"
     },
     {
       "name": "Headless UI",
+      "slug": "headless-ui",
       "full_name": "tailwindlabs/headlessui",
       "description": "Completely unstyled, fully accessible UI components, designed to integrate beautifully with Tailwind CSS.",
       "stars": 18434,
@@ -964,11 +971,11 @@
       "owner_id": 67109815,
       "icon": "headlessui.svg",
       "created_at": "2020-09-16T09:53:09.000Z",
-      "url": "https://headlessui.com",
-      "slug": "headless-ui"
+      "url": "https://headlessui.com"
     },
     {
       "name": "Directus",
+      "slug": "directus",
       "full_name": "directus/directus",
       "description": "A real-time API and App dashboard for managing SQL database content.",
       "stars": 19305,
@@ -977,11 +984,11 @@
       "tags": ["nodejs-framework", "cms", "graphql", "vue", "sql"],
       "owner_id": 15967950,
       "created_at": "2012-12-12T01:35:36.000Z",
-      "url": "https://directus.io",
-      "slug": "directus"
+      "url": "https://directus.io"
     },
     {
       "name": "VueUse",
+      "slug": "vueuse",
       "full_name": "vueuse/vueuse",
       "description": "Collection of essential Vue Composition Utilities for Vue 2 and 3",
       "stars": 13267,
@@ -990,11 +997,11 @@
       "tags": ["vue", "util"],
       "owner_id": 77578415,
       "created_at": "2019-12-14T06:44:59.000Z",
-      "url": "https://vueuse.org",
-      "slug": "vueuse"
+      "url": "https://vueuse.org"
     },
     {
       "name": "Electron",
+      "slug": "electron",
       "full_name": "electron/electron",
       "description": "Build cross-platform desktop apps with JavaScript, HTML, and CSS",
       "stars": 105316,
@@ -1004,11 +1011,11 @@
       "owner_id": 13409222,
       "icon": "electron.svg",
       "created_at": "2013-04-12T01:47:36.000Z",
-      "url": "https://electronjs.org",
-      "slug": "electron"
+      "url": "https://electronjs.org"
     },
     {
       "name": "Vitest",
+      "slug": "vitest",
       "full_name": "vitest-dev/vitest",
       "description": "A Vite-native test framework. It's fast!",
       "stars": 7457,
@@ -1018,11 +1025,11 @@
       "owner_id": 95747107,
       "icon": "vitest.svg",
       "created_at": "2021-12-03T19:19:49.000Z",
-      "url": "https://vitest.dev",
-      "slug": "vitest"
+      "url": "https://vitest.dev"
     },
     {
       "name": "UnoCSS",
+      "slug": "unocss",
       "full_name": "unocss/unocss",
       "description": "The instant on-demand atomic CSS engine.",
       "stars": 8268,
@@ -1032,11 +1039,11 @@
       "owner_id": 93899228,
       "icon": "unocss.svg",
       "created_at": "2021-09-30T17:06:46.000Z",
-      "url": "https://uno.antfu.me",
-      "slug": "unocss"
+      "url": "https://uno.antfu.me"
     },
     {
       "name": "Rome",
+      "slug": "rome",
       "full_name": "rome/tools",
       "description": "Unified developer tools for JavaScript, TypeScript, and the web",
       "stars": 22097,
@@ -1046,11 +1053,11 @@
       "owner_id": 85328842,
       "icon": "rome.svg",
       "created_at": "2020-02-20T05:57:33.000Z",
-      "url": "https://docs.rome.tools/",
-      "slug": "rome"
+      "url": "https://docs.rome.tools/"
     },
     {
       "name": "Redwood",
+      "slug": "redwood",
       "full_name": "redwoodjs/redwood",
       "description": "The App Framework for Startups",
       "stars": 15525,
@@ -1060,11 +1067,11 @@
       "owner_id": 45050444,
       "icon": "redwood.svg",
       "created_at": "2019-06-09T20:17:57.000Z",
-      "url": "https://redwoodjs.com",
-      "slug": "redwood"
+      "url": "https://redwoodjs.com"
     },
     {
       "name": "Pinia",
+      "slug": "pinia",
       "full_name": "vuejs/pinia",
       "description": "Intuitive, type safe, light and flexible Store for Vue using the composition api with DevTools support",
       "stars": 9558,
@@ -1074,11 +1081,11 @@
       "owner_id": 6128107,
       "icon": "pinia.svg",
       "created_at": "2019-11-18T21:05:01.000Z",
-      "url": "https://pinia.vuejs.org",
-      "slug": "pinia"
+      "url": "https://pinia.vuejs.org"
     },
     {
       "name": "Element Plus",
+      "slug": "element-plus",
       "full_name": "element-plus/element-plus",
       "description": "A Vue.js 3 UI Library made by Element team",
       "stars": 18282,
@@ -1087,11 +1094,11 @@
       "tags": ["component", "vue"],
       "owner_id": 68583457,
       "created_at": "2020-07-21T06:51:19.000Z",
-      "url": "https://element-plus.org",
-      "slug": "element-plus"
+      "url": "https://element-plus.org"
     },
     {
       "name": "Jotai",
+      "slug": "jotai",
       "full_name": "pmndrs/jotai",
       "description": "Primitive and flexible state management for React",
       "stars": 11534,
@@ -1101,10 +1108,11 @@
       "owner_id": 45790596,
       "created_at": "2020-08-11T23:15:36.000Z",
       "url": "https://jotai.org",
-      "slug": "jotai"
+      "icon": "jotai.webp"
     },
     {
       "name": "htmx",
+      "slug": "htmx",
       "full_name": "bigskysoftware/htmx",
       "description": "</> htmx - high power tools for HTML",
       "stars": 10247,
@@ -1114,11 +1122,11 @@
       "owner_id": 48798027,
       "icon": "htmx.svg",
       "created_at": "2020-04-13T16:17:51.000Z",
-      "url": "https://htmx.org",
-      "slug": "htmx"
+      "url": "https://htmx.org"
     },
     {
       "name": "esbuild",
+      "slug": "esbuild",
       "full_name": "evanw/esbuild",
       "description": "An extremely fast JavaScript and CSS bundler and minifier",
       "stars": 34264,
@@ -1128,11 +1136,11 @@
       "owner_id": 406394,
       "icon": "esbuild.svg",
       "created_at": "2016-06-14T16:08:50.000Z",
-      "url": "https://esbuild.github.io/",
-      "slug": "esbuild"
+      "url": "https://esbuild.github.io/"
     },
     {
       "name": "Fastify",
+      "slug": "fastify",
       "full_name": "fastify/fastify",
       "description": "Fast and low overhead web framework, for Node.js",
       "stars": 26055,
@@ -1142,11 +1150,11 @@
       "owner_id": 24939410,
       "icon": "fastify.svg",
       "created_at": "2016-09-28T19:10:14.000Z",
-      "url": "https://www.fastify.io",
-      "slug": "fastify"
+      "url": "https://www.fastify.io"
     },
     {
       "name": "Hasura GraphQL Engine",
+      "slug": "hasura-graphql-engine",
       "full_name": "hasura/graphql-engine",
       "description": "Blazing fast, instant realtime GraphQL APIs on your DB with fine grained access control, also trigger webhooks on database events.",
       "stars": 28989,
@@ -1156,11 +1164,11 @@
       "owner_id": 13966722,
       "icon": "hasura.svg",
       "created_at": "2018-06-18T07:57:36.000Z",
-      "url": "https://hasura.io",
-      "slug": "hasura-graphql-engine"
+      "url": "https://hasura.io"
     },
     {
       "name": "Express",
+      "slug": "express",
       "full_name": "expressjs/express",
       "description": "Fast, unopinionated, minimalist web framework for node.",
       "stars": 59514,
@@ -1170,11 +1178,11 @@
       "owner_id": 5658226,
       "icon": "express.svg",
       "created_at": "2009-06-26T18:56:01.000Z",
-      "url": "https://expressjs.com",
-      "slug": "express"
+      "url": "https://expressjs.com"
     },
     {
       "name": "XState",
+      "slug": "xstate",
       "full_name": "statelyai/xstate",
       "description": "State machines and statecharts for the modern web.",
       "stars": 22251,
@@ -1184,11 +1192,11 @@
       "owner_id": 61783956,
       "icon": "xstate.svg",
       "created_at": "2015-09-14T15:04:15.000Z",
-      "url": "https://xstate.js.org/docs",
-      "slug": "xstate"
+      "url": "https://xstate.js.org/docs"
     },
     {
       "name": "MemLab",
+      "slug": "memlab",
       "full_name": "facebook/memlab",
       "description": "A framework for finding JavaScript memory leaks and analyzing heap snapshots",
       "stars": 3629,
@@ -1210,11 +1218,11 @@
       "tags": ["performance", "test"],
       "owner_id": 69631,
       "created_at": "2022-05-26T20:53:35.000Z",
-      "url": "https://facebook.github.io/memlab/",
-      "slug": "memlab"
+      "url": "https://facebook.github.io/memlab/"
     },
     {
       "name": "Lit",
+      "slug": "lit",
       "full_name": "lit/lit",
       "description": "A simple library for building fast, lightweight web components",
       "stars": 13477,
@@ -1224,11 +1232,11 @@
       "owner_id": 18489846,
       "icon": "lit.svg",
       "created_at": "2017-06-29T16:27:16.000Z",
-      "url": "https://lit.dev",
-      "slug": "lit"
+      "url": "https://lit.dev"
     },
     {
       "name": "Jest",
+      "slug": "jest",
       "full_name": "facebook/jest",
       "description": "Delightful JavaScript Testing.",
       "stars": 41065,
@@ -1238,11 +1246,11 @@
       "owner_id": 69631,
       "icon": "jest.svg",
       "created_at": "2013-12-10T00:18:04.000Z",
-      "url": "https://jestjs.io",
-      "slug": "jest"
+      "url": "https://jestjs.io"
     },
     {
       "name": "Mock Service Worker",
+      "slug": "mock-service-worker",
       "full_name": "mswjs/msw",
       "description": "Seamless REST/GraphQL API mocking library for browser and Node.js.",
       "stars": 11326,
@@ -1251,11 +1259,11 @@
       "tags": ["test", "serviceworker"],
       "owner_id": 64637271,
       "created_at": "2018-11-13T14:58:44.000Z",
-      "url": "https://mswjs.io",
-      "slug": "mock-service-worker"
+      "url": "https://mswjs.io"
     },
     {
       "name": "Alpine.js",
+      "slug": "alpinejs",
       "full_name": "alpinejs/alpine",
       "description": "A rugged, minimal framework for composing JavaScript behavior in your markup.",
       "stars": 22608,
@@ -1265,11 +1273,11 @@
       "owner_id": 59030169,
       "icon": "alpine.svg",
       "created_at": "2019-11-28T13:51:55.000Z",
-      "url": "https://alpinejs.dev",
-      "slug": "alpinejs"
+      "url": "https://alpinejs.dev"
     },
     {
       "name": "Nativefier",
+      "slug": "nativefier",
       "full_name": "nativefier/nativefier",
       "description": "Make any web page a desktop application",
       "stars": 32593,
@@ -1277,11 +1285,11 @@
       "monthly": [228, 319, 211, 272, 460, 199, 196, 232, 224, 212, 237, 252],
       "tags": ["desktop"],
       "owner_id": 69503009,
-      "created_at": "2015-07-05T05:56:42.000Z",
-      "slug": "nativefier"
+      "created_at": "2015-07-05T05:56:42.000Z"
     },
     {
       "name": "Preact",
+      "slug": "preact",
       "full_name": "preactjs/preact",
       "description": "Fast 3kB React alternative with the same modern API. Components & Virtual DOM.",
       "stars": 33558,
@@ -1291,11 +1299,11 @@
       "owner_id": 26872990,
       "icon": "preact.svg",
       "created_at": "2015-09-11T02:40:18.000Z",
-      "url": "https://preactjs.com",
-      "slug": "preact"
+      "url": "https://preactjs.com"
     },
     {
       "name": "Lerna",
+      "slug": "lerna",
       "full_name": "lerna/lerna",
       "description": "Lerna is a fast, modern build system for managing and publishing multiple JavaScript/TypeScript packages from the same repository.",
       "stars": 34109,
@@ -1304,11 +1312,11 @@
       "tags": ["monorepo", "build"],
       "owner_id": 19333396,
       "created_at": "2015-12-04T09:36:55.000Z",
-      "url": "https://lerna.js.org",
-      "slug": "lerna"
+      "url": "https://lerna.js.org"
     },
     {
       "name": "Expo",
+      "slug": "expo",
       "full_name": "expo/expo",
       "description": "An open-source platform for making universal native apps with React. Expo runs on Android, iOS, and the web.",
       "stars": 18609,
@@ -1318,11 +1326,11 @@
       "owner_id": 12504344,
       "icon": "expo.svg",
       "created_at": "2016-08-15T17:14:25.000Z",
-      "url": "https://docs.expo.dev",
-      "slug": "expo"
+      "url": "https://docs.expo.dev"
     },
     {
       "name": "Recoil",
+      "slug": "recoil",
       "full_name": "facebookexperimental/Recoil",
       "description": "An experimental state management library for React apps",
       "stars": 18205,
@@ -1332,11 +1340,11 @@
       "owner_id": 12853545,
       "icon": "recoil.svg",
       "created_at": "2020-05-04T19:44:15.000Z",
-      "url": "https://recoiljs.org/",
-      "slug": "recoil"
+      "url": "https://recoiljs.org/"
     },
     {
       "name": "Nextra",
+      "slug": "nextra",
       "full_name": "shuding/nextra",
       "description": "Simple, powerful and flexible site generation framework with everything you love from Next.js.",
       "stars": 5493,
@@ -1346,11 +1354,11 @@
       "owner_id": 3676859,
       "icon": "nextra.svg",
       "created_at": "2020-06-15T16:39:34.000Z",
-      "url": "https://nextra.site",
-      "slug": "nextra"
+      "url": "https://nextra.site"
     },
     {
       "name": "React Native Skia",
+      "slug": "react-native-skia",
       "full_name": "Shopify/react-native-skia",
       "description": "High-performance React Native Graphics using Skia",
       "stars": 4656,
@@ -1359,11 +1367,11 @@
       "tags": ["react-native", "animation"],
       "owner_id": 8085,
       "created_at": "2021-11-08T13:19:09.000Z",
-      "url": "https://shopify.github.io/react-native-skia",
-      "slug": "react-native-skia"
+      "url": "https://shopify.github.io/react-native-skia"
     },
     {
       "name": "vanilla-extract",
+      "slug": "vanilla-extract",
       "full_name": "vanilla-extract-css/vanilla-extract",
       "description": "Zero-runtime Stylesheets-in-TypeScript",
       "stars": 7131,
@@ -1373,11 +1381,11 @@
       "owner_id": 112610040,
       "icon": "vanilla.svg",
       "created_at": "2021-03-26T05:10:54.000Z",
-      "url": "https://vanilla-extract.style",
-      "slug": "vanilla-extract"
+      "url": "https://vanilla-extract.style"
     },
     {
       "name": "Nuxt",
+      "slug": "nuxt",
       "full_name": "nuxt/nuxt.js",
       "description": "The Intuitive Vue(2) Framework",
       "stars": 41772,
@@ -1385,13 +1393,13 @@
       "monthly": [85, 139, 169, 161, 149, 279, 150, 289, 610, 218, 218, 205],
       "tags": ["vue", "universal", "nodejs-framework", "ssg"],
       "owner_id": 23360933,
-      "icon": "nuxt2.svg",
+      "icon": "nuxt.svg",
       "created_at": "2016-10-26T11:18:47.000Z",
-      "url": "https://nuxtjs.org",
-      "slug": "nuxt"
+      "url": "https://nuxtjs.org"
     },
     {
       "name": "Selenium",
+      "slug": "selenium",
       "full_name": "SeleniumHQ/selenium",
       "description": "A browser automation framework and ecosystem.",
       "stars": 25515,
@@ -1400,11 +1408,11 @@
       "tags": ["test", "auto"],
       "owner_id": 983927,
       "created_at": "2013-01-14T21:40:56.000Z",
-      "url": "https://selenium.dev",
-      "slug": "selenium"
+      "url": "https://selenium.dev"
     },
     {
       "name": "Valtio",
+      "slug": "valtio",
       "full_name": "pmndrs/valtio",
       "description": "Valtio makes proxy-state simple  for React and Vanilla",
       "stars": 6067,
@@ -1413,11 +1421,11 @@
       "tags": ["state", "react"],
       "owner_id": 45790596,
       "created_at": "2020-11-16T22:30:51.000Z",
-      "url": "http://valtio.pmnd.rs",
-      "slug": "valtio"
+      "url": "http://valtio.pmnd.rs"
     },
     {
       "name": "Ionic",
+      "slug": "ionic",
       "full_name": "ionic-team/ionic-framework",
       "description": "A powerful cross-platform UI toolkit for building native-quality iOS, Android, and Progressive Web Apps with HTML, CSS, and JavaScript.",
       "stars": 48467,
@@ -1427,11 +1435,11 @@
       "owner_id": 3171503,
       "icon": "ionic.svg",
       "created_at": "2013-08-20T23:06:02.000Z",
-      "url": "https://ionicframework.com",
-      "slug": "ionic"
+      "url": "https://ionicframework.com"
     },
     {
       "name": "Quasar",
+      "slug": "quasar",
       "full_name": "quasarframework/quasar",
       "description": "Responsive Single Page Apps, Server-side Render Apps, Progressive Web Apps, Hybrid Mobile Apps (that look native!) & Electron Apps, all using the same codebase.",
       "stars": 22652,
@@ -1441,11 +1449,11 @@
       "owner_id": 23064371,
       "icon": "quasar.svg",
       "created_at": "2015-10-05T15:45:36.000Z",
-      "url": "https://quasar.dev",
-      "slug": "quasar"
+      "url": "https://quasar.dev"
     },
     {
       "name": "Eleventy",
+      "slug": "eleventy",
       "full_name": "11ty/eleventy",
       "description": "A simpler static site generator. An alternative to Jekyll. Transforms a directory of templates (of varying types) into HTML.",
       "stars": 13445,
@@ -1454,11 +1462,11 @@
       "tags": ["ssg"],
       "owner_id": 35147177,
       "created_at": "2017-11-27T05:19:00.000Z",
-      "url": "https://www.11ty.dev/",
-      "slug": "eleventy"
+      "url": "https://www.11ty.dev/"
     },
     {
       "name": "Styled Components",
+      "slug": "styled-components",
       "full_name": "styled-components/styled-components",
       "description": "Visual primitives for the component age. Use the best bits of ES6 and CSS to style your apps without stress",
       "stars": 38020,
@@ -1467,11 +1475,11 @@
       "tags": ["css-in-js"],
       "owner_id": 20658825,
       "created_at": "2016-08-16T06:41:32.000Z",
-      "url": "https://styled-components.com",
-      "slug": "styled-components"
+      "url": "https://styled-components.com"
     },
     {
       "name": "Stitches",
+      "slug": "stitches",
       "full_name": "stitchesjs/stitches",
       "description": "CSS-in-JS with near-zero runtime, SSR, multi-variant support, and a best-in-class developer experience.",
       "stars": 6811,
@@ -1481,11 +1489,11 @@
       "owner_id": 106618147,
       "icon": "stitches.svg",
       "created_at": "2020-04-14T07:07:35.000Z",
-      "url": "https://stitches.dev",
-      "slug": "stitches"
+      "url": "https://stitches.dev"
     },
     {
       "name": "Webpack",
+      "slug": "webpack",
       "full_name": "webpack/webpack",
       "description": "A bundler for javascript and friends. Packs many modules into a few bundled assets. Code Splitting allows for loading parts of the application on demand. Through \"loaders\", modules can be CommonJs, AMD, ES6 modules, CSS, Images, JSON, Coffeescript, LESS, ... and your custom stuff.",
       "stars": 62313,
@@ -1495,11 +1503,11 @@
       "owner_id": 2105791,
       "icon": "webpack.svg",
       "created_at": "2012-03-10T10:08:14.000Z",
-      "url": "https://webpack.js.org",
-      "slug": "webpack"
+      "url": "https://webpack.js.org"
     },
     {
       "name": "Histoire",
+      "slug": "histoire",
       "full_name": "histoire-dev/histoire",
       "description": "Fast and beautiful interactive component playgrounds, powered by Vite",
       "stars": 2079,
@@ -1521,11 +1529,11 @@
       "tags": ["playground", "vue", "test", "vite"],
       "owner_id": 101679800,
       "created_at": "2022-01-21T23:03:57.000Z",
-      "url": "https://histoire.dev",
-      "slug": "histoire"
+      "url": "https://histoire.dev"
     },
     {
       "name": "Parcel",
+      "slug": "parcel",
       "full_name": "parcel-bundler/parcel",
       "description": "The zero configuration build tool for the web.",
       "stars": 41822,
@@ -1535,11 +1543,11 @@
       "owner_id": 32607881,
       "icon": "parcel.svg",
       "created_at": "2017-08-07T16:36:47.000Z",
-      "url": "https://parceljs.org",
-      "slug": "parcel"
+      "url": "https://parceljs.org"
     },
     {
       "name": "NativeBase",
+      "slug": "nativebase",
       "full_name": "GeekyAnts/NativeBase",
       "description": "Mobile-first, accessible components for React Native & Web to build consistent UI across Android, iOS and Web.",
       "stars": 18834,
@@ -1549,11 +1557,11 @@
       "owner_id": 18482943,
       "icon": "nativebase.svg",
       "created_at": "2016-04-15T11:37:23.000Z",
-      "url": "https://nativebase.io/",
-      "slug": "nativebase"
+      "url": "https://nativebase.io/"
     },
     {
       "name": "Hexo",
+      "slug": "hexo",
       "full_name": "hexojs/hexo",
       "description": "A fast, simple & powerful blog framework, powered by Node.js.",
       "stars": 35957,
@@ -1563,11 +1571,11 @@
       "owner_id": 6375567,
       "icon": "hexo.svg",
       "created_at": "2012-09-23T15:17:08.000Z",
-      "url": "https://hexo.io",
-      "slug": "hexo"
+      "url": "https://hexo.io"
     },
     {
       "name": "Gatsby",
+      "slug": "gatsby",
       "full_name": "gatsbyjs/gatsby",
       "description": "The fastest frontend for the headless web. Build modern websites with React.",
       "stars": 53999,
@@ -1577,11 +1585,11 @@
       "owner_id": 12551863,
       "icon": "gatsby.svg",
       "created_at": "2015-05-21T22:43:05.000Z",
-      "url": "https://www.gatsbyjs.com",
-      "slug": "gatsby"
+      "url": "https://www.gatsbyjs.com"
     },
     {
       "name": "Flipper",
+      "slug": "flipper",
       "full_name": "facebook/flipper",
       "description": "A desktop debugging platform for mobile developers.",
       "stars": 12238,
@@ -1590,11 +1598,11 @@
       "tags": ["mobile", "devtool"],
       "owner_id": 69631,
       "created_at": "2018-04-12T16:47:36.000Z",
-      "url": "https://fbflipper.com/",
-      "slug": "flipper"
+      "url": "https://fbflipper.com/"
     },
     {
       "name": "Capacitor",
+      "slug": "capacitor",
       "full_name": "ionic-team/capacitor",
       "description": "Build cross-platform Native Progressive Web Apps for iOS, Android, and the Web",
       "stars": 8564,
@@ -1603,11 +1611,11 @@
       "tags": ["mobile"],
       "owner_id": 3171503,
       "created_at": "2017-11-18T21:38:09.000Z",
-      "url": "https://capacitorjs.com",
-      "slug": "capacitor"
+      "url": "https://capacitorjs.com"
     },
     {
       "name": "Redux",
+      "slug": "redux",
       "full_name": "reduxjs/redux",
       "description": "Predictable state container for JavaScript apps",
       "stars": 59082,
@@ -1617,11 +1625,11 @@
       "owner_id": 13142323,
       "icon": "redux.svg",
       "created_at": "2015-05-29T23:53:15.000Z",
-      "url": "https://redux.js.org",
-      "slug": "redux"
+      "url": "https://redux.js.org"
     },
     {
       "name": "petite-vue",
+      "slug": "petite-vue",
       "full_name": "vuejs/petite-vue",
       "description": "6kb subset of Vue optimized for progressive enhancement",
       "stars": 7282,
@@ -1629,11 +1637,11 @@
       "monthly": [98, 125, 158, 177, 140, 106, 162, 149, 137, 166, 183, 162],
       "tags": ["vue", "framework"],
       "owner_id": 6128107,
-      "created_at": "2021-07-01T04:22:47.000Z",
-      "slug": "petite-vue"
+      "created_at": "2021-07-01T04:22:47.000Z"
     },
     {
       "name": "Nhost",
+      "slug": "nhost",
       "full_name": "nhost/nhost",
       "description": "The Open Source Firebase Alternative with GraphQL.",
       "stars": 5525,
@@ -1655,11 +1663,11 @@
       "tags": ["realtime", "websocket", "graphql", "serverless", "auth"],
       "owner_id": 48448799,
       "created_at": "2021-02-09T13:33:34.000Z",
-      "url": "https://nhost.io",
-      "slug": "nhost"
+      "url": "https://nhost.io"
     },
     {
       "name": "FlashList",
+      "slug": "flashlist",
       "full_name": "Shopify/flash-list",
       "description": "Fast & Performant React Native List",
       "stars": 3209,
@@ -1681,11 +1689,11 @@
       "tags": ["react-native", "virtual-list"],
       "owner_id": 8085,
       "created_at": "2021-12-20T15:48:14.000Z",
-      "url": "https://shopify.github.io/flash-list/",
-      "slug": "flashlist"
+      "url": "https://shopify.github.io/flash-list/"
     },
     {
       "name": "Rollup",
+      "slug": "rollup",
       "full_name": "rollup/rollup",
       "description": "Next-generation ES module bundler",
       "stars": 22775,
@@ -1695,11 +1703,11 @@
       "owner_id": 12554859,
       "icon": "rollup.svg",
       "created_at": "2015-05-14T22:26:28.000Z",
-      "url": "https://rollupjs.org",
-      "slug": "rollup"
+      "url": "https://rollupjs.org"
     },
     {
       "name": "Emotion",
+      "slug": "emotion",
       "full_name": "emotion-js/emotion",
       "description": "CSS-in-JS library designed for high performance style composition",
       "stars": 15892,
@@ -1708,11 +1716,11 @@
       "tags": ["css-in-js"],
       "owner_id": 31557565,
       "created_at": "2017-05-27T04:23:45.000Z",
-      "url": "https://emotion.sh/",
-      "slug": "emotion"
+      "url": "https://emotion.sh/"
     },
     {
       "name": "Twin",
+      "slug": "twin",
       "full_name": "ben-rogerson/twin.macro",
       "description": "Twin blends the magic of Tailwind with the flexibility of css-in-js (emotion, styled-components, stitches and goober) at build time.",
       "stars": 6757,
@@ -1720,11 +1728,11 @@
       "monthly": [122, 169, 160, 103, 150, 105, 128, 92, 136, 132, 116, 150],
       "tags": ["css-in-js", "react", "tailwind"],
       "owner_id": 21288568,
-      "created_at": "2020-02-19T04:45:25.000Z",
-      "slug": "twin"
+      "created_at": "2020-02-19T04:45:25.000Z"
     },
     {
       "name": "NativeWind",
+      "slug": "nativewind",
       "full_name": "marklawlor/nativewind",
       "description": "React Native utility-first universal design system - powered by Tailwind CSS",
       "stars": 1571,
@@ -1746,11 +1754,11 @@
       "tags": ["react-native", "component", "tailwind", "css-in-js"],
       "owner_id": 3946701,
       "created_at": "2022-04-02T12:30:41.000Z",
-      "url": "https://nativewind.dev",
-      "slug": "nativewind"
+      "url": "https://nativewind.dev"
     },
     {
       "name": "GraphQL Code Generator",
+      "slug": "graphql-code-generator",
       "full_name": "dotansimha/graphql-code-generator",
       "description": "A tool for generating code based on a GraphQL schema and GraphQL operations (query/mutation/subscription), with flexible support for custom plugins.",
       "stars": 9609,
@@ -1760,11 +1768,11 @@
       "owner_id": 3680083,
       "icon": "graphql-code-generator.svg",
       "created_at": "2016-12-05T19:15:11.000Z",
-      "url": "https://www.the-guild.dev/graphql/codegen/",
-      "slug": "graphql-code-generator"
+      "url": "https://www.the-guild.dev/graphql/codegen/"
     },
     {
       "name": "Neutralino",
+      "slug": "neutralino",
       "full_name": "neutralinojs/neutralinojs",
       "description": "Portable and lightweight cross-platform desktop application development framework",
       "stars": 6311,
@@ -1773,11 +1781,11 @@
       "tags": ["desktop"],
       "owner_id": 36976817,
       "created_at": "2018-06-23T03:30:41.000Z",
-      "url": "https://neutralino.js.org",
-      "slug": "neutralino"
+      "url": "https://neutralino.js.org"
     },
     {
       "name": "Linaria",
+      "slug": "linaria",
       "full_name": "callstack/linaria",
       "description": "Zero-runtime CSS in JS library",
       "stars": 9999,
@@ -1787,11 +1795,11 @@
       "owner_id": 42239399,
       "icon": "linaria.svg",
       "created_at": "2017-05-23T00:52:34.000Z",
-      "url": "https://linaria.dev",
-      "slug": "linaria"
+      "url": "https://linaria.dev"
     },
     {
       "name": "Signals",
+      "slug": "signals",
       "full_name": "preactjs/signals",
       "description": "Manage state with style in every framework",
       "stars": 1533,
@@ -1813,11 +1821,11 @@
       "tags": ["state", "react", "reactive"],
       "owner_id": 26872990,
       "created_at": "2022-08-08T21:29:28.000Z",
-      "url": "https://preactjs.com/blog/introducing-signals/",
-      "slug": "signals"
+      "url": "https://preactjs.com/blog/introducing-signals/"
     },
     {
       "name": "GraphiQL",
+      "slug": "graphiql",
       "full_name": "graphql/graphiql",
       "description": "GraphiQL & the GraphQL LSP Reference Ecosystem for building browser & IDE tools.",
       "stars": 14511,
@@ -1825,11 +1833,11 @@
       "monthly": [116, 116, 99, 134, 188, 94, 98, 100, 95, 106, 119, 204],
       "tags": ["graphql"],
       "owner_id": 12972006,
-      "created_at": "2015-08-11T02:56:22.000Z",
-      "slug": "graphiql"
+      "created_at": "2015-08-11T02:56:22.000Z"
     },
     {
       "name": "Outstatic",
+      "slug": "outstatic",
       "full_name": "avitorio/outstatic",
       "description": "A static CMS for Next.js ",
       "stars": 1433,
@@ -1851,11 +1859,11 @@
       "tags": ["cms", "nextjs", "ssg"],
       "owner_id": 1417109,
       "created_at": "2022-09-24T16:40:37.000Z",
-      "url": "https://Outstatic.com",
-      "slug": "outstatic"
+      "url": "https://Outstatic.com"
     },
     {
       "name": "Stencil",
+      "slug": "stencil",
       "full_name": "ionic-team/stencil",
       "description": "A toolchain for building scalable, enterprise-ready component systems on top of TypeScript and Web Component standards. Stencil components can be distributed natively to React, Angular, Vue, and traditional web developers from a single, framework-agnostic codebase.",
       "stars": 11313,
@@ -1865,11 +1873,11 @@
       "owner_id": 3171503,
       "icon": "stencil.svg",
       "created_at": "2017-02-15T18:57:07.000Z",
-      "url": "https://stenciljs.com",
-      "slug": "stencil"
+      "url": "https://stenciljs.com"
     },
     {
       "name": "Webiny",
+      "slug": "webiny",
       "full_name": "webiny/webiny-js",
       "description": "Open-source serverless enterprise CMS. Includes a headless CMS, page builder, form builder, and file manager. Easy to customize and expand. Deploys to AWS.",
       "stars": 6312,
@@ -1878,11 +1886,11 @@
       "tags": ["graphql", "cms"],
       "owner_id": 3808429,
       "created_at": "2018-01-09T13:09:44.000Z",
-      "url": "https://www.webiny.com",
-      "slug": "webiny"
+      "url": "https://www.webiny.com"
     },
     {
       "name": "MobX",
+      "slug": "mobx",
       "full_name": "mobxjs/mobx",
       "description": "Simple, scalable state management.",
       "stars": 26030,
@@ -1892,11 +1900,11 @@
       "owner_id": 17475736,
       "icon": "mobx.svg",
       "created_at": "2015-03-14T14:31:38.000Z",
-      "url": "http://mobx.js.org",
-      "slug": "mobx"
+      "url": "http://mobx.js.org"
     },
     {
       "name": "Apollo client",
+      "slug": "apollo-client",
       "full_name": "apollographql/apollo-client",
       "description": "A fully-featured, production ready caching GraphQL client for every UI framework and GraphQL server.",
       "stars": 18356,
@@ -1906,11 +1914,11 @@
       "owner_id": 17189275,
       "icon": "apollo.svg",
       "created_at": "2016-02-26T20:25:00.000Z",
-      "url": "https://apollographql.com/client",
-      "slug": "apollo-client"
+      "url": "https://apollographql.com/client"
     },
     {
       "name": "Marko",
+      "slug": "marko",
       "full_name": "marko-js/marko",
       "description": "A declarative, HTML-based language that makes building web apps fun",
       "stars": 12061,
@@ -1920,11 +1928,11 @@
       "owner_id": 11873696,
       "icon": "marko.svg",
       "created_at": "2014-01-07T23:58:21.000Z",
-      "url": "https://markojs.com/",
-      "slug": "marko"
+      "url": "https://markojs.com/"
     },
     {
       "name": "Twind",
+      "slug": "twind",
       "full_name": "tw-in-js/twind",
       "description": "The smallest, fastest, most feature complete Tailwind-in-JS solution in existence.",
       "stars": 3081,
@@ -1933,11 +1941,11 @@
       "tags": ["css-in-js", "tailwind"],
       "owner_id": 75540906,
       "created_at": "2020-12-05T17:59:21.000Z",
-      "url": "https://twind.style",
-      "slug": "twind"
+      "url": "https://twind.style"
     },
     {
       "name": "Nano stores",
+      "slug": "nano-stores",
       "full_name": "nanostores/nanostores",
       "description": "A tiny (258 bytes) state manager for React/RN/Preact/Vue/Svelte with many atomic tree-shakable stores",
       "stars": 2287,
@@ -1945,11 +1953,11 @@
       "monthly": [92, 148, 163, 171, 220, 101, 23, 23, 23, 33, 37, 53],
       "tags": ["state"],
       "owner_id": 85066968,
-      "created_at": "2020-10-14T19:51:28.000Z",
-      "slug": "nano-stores"
+      "created_at": "2020-10-14T19:51:28.000Z"
     },
     {
       "name": "Relay",
+      "slug": "relay",
       "full_name": "facebook/relay",
       "description": "Relay is a JavaScript framework for building data-driven React applications.",
       "stars": 17521,
@@ -1959,11 +1967,11 @@
       "owner_id": 69631,
       "icon": "relay.svg",
       "created_at": "2015-08-10T22:09:16.000Z",
-      "url": "https://relay.dev",
-      "slug": "relay"
+      "url": "https://relay.dev"
     },
     {
       "name": "CSS Modules",
+      "slug": "css-modules",
       "full_name": "css-modules/css-modules",
       "description": "Documentation about css-modules",
       "stars": 16534,
@@ -1971,11 +1979,11 @@
       "monthly": [65, 59, 75, 76, 82, 70, 76, 85, 70, 79, 98, 66],
       "tags": ["css-in-js"],
       "owner_id": 12612655,
-      "created_at": "2015-05-25T21:54:47.000Z",
-      "slug": "css-modules"
+      "created_at": "2015-05-25T21:54:47.000Z"
     },
     {
       "name": "electron-builder",
+      "slug": "electron-builder",
       "full_name": "electron-userland/electron-builder",
       "description": "A complete solution to package and build a ready for distribution Electron app with “auto update” support out of the box",
       "stars": 12528,
@@ -1984,8 +1992,7 @@
       "tags": ["desktop"],
       "owner_id": 17519142,
       "created_at": "2015-05-21T07:45:02.000Z",
-      "url": "https://www.electron.build",
-      "slug": "electron-builder"
+      "url": "https://www.electron.build"
     }
   ],
   "tags": [

--- a/data/2023/projects.json
+++ b/data/2023/projects.json
@@ -4,6 +4,7 @@
   "projects": [
     {
       "name": "shadcn/ui",
+      "slug": "shadcnui",
       "full_name": "shadcn-ui/ui",
       "description": "Beautifully designed components that you can copy and paste into your apps. Accessible. Customizable. Open Source.",
       "stars": 48364,
@@ -15,11 +16,11 @@
       "owner_id": 139895814,
       "icon": "shadcnui.svg",
       "created_at": "2023-01-04T12:43:27.000Z",
-      "url": "https://ui.shadcn.com",
-      "slug": "shadcnui"
+      "url": "https://ui.shadcn.com"
     },
     {
       "name": "Bun",
+      "slug": "bun",
       "full_name": "oven-sh/bun",
       "description": "Incredibly fast JavaScript runtime, bundler, test runner, and package manager – all in one",
       "stars": 68101,
@@ -31,11 +32,11 @@
       "owner_id": 108928776,
       "icon": "bun.svg",
       "created_at": "2021-04-14T00:48:17.000Z",
-      "url": "https://bun.sh",
-      "slug": "bun"
+      "url": "https://bun.sh"
     },
     {
       "name": "Excalidraw",
+      "slug": "excalidraw",
       "full_name": "excalidraw/excalidraw",
       "description": "Virtual whiteboard for sketching hand-drawn like diagrams",
       "stars": 67903,
@@ -47,11 +48,11 @@
       "owner_id": 59452120,
       "icon": "excalidraw.svg",
       "created_at": "2020-01-02T01:04:43.000Z",
-      "url": "https://excalidraw.com",
-      "slug": "excalidraw"
+      "url": "https://excalidraw.com"
     },
     {
       "name": "tldraw",
+      "slug": "tldraw",
       "full_name": "tldraw/tldraw",
       "description": "Infinite canvas.",
       "stars": 31168,
@@ -63,11 +64,11 @@
       "owner_id": 86724562,
       "icon": "tldraw.svg",
       "created_at": "2021-05-09T11:48:37.000Z",
-      "url": "https://tldraw.com",
-      "slug": "tldraw"
+      "url": "https://tldraw.com"
     },
     {
       "name": "Next.js",
+      "slug": "nextjs",
       "full_name": "vercel/next.js",
       "description": "The React Framework",
       "stars": 118047,
@@ -87,11 +88,11 @@
       "owner_id": 14985020,
       "icon": "nextjs.svg",
       "created_at": "2016-10-05T23:32:51.000Z",
-      "url": "https://nextjs.org",
-      "slug": "nextjs"
+      "url": "https://nextjs.org"
     },
     {
       "name": "Supabase",
+      "slug": "supabase",
       "full_name": "supabase/supabase",
       "description": "The open source Firebase alternative",
       "stars": 62839,
@@ -103,10 +104,11 @@
       "owner_id": 54469796,
       "created_at": "2019-10-12T05:56:49.000Z",
       "url": "https://supabase.com",
-      "slug": "supabase"
+      "icon": "supabase.svg"
     },
     {
       "name": "React",
+      "slug": "react",
       "full_name": "facebook/react",
       "description": "The library for web and native user interfaces.",
       "stars": 218523,
@@ -118,11 +120,11 @@
       "owner_id": 69631,
       "icon": "react.svg",
       "created_at": "2013-05-24T16:15:54.000Z",
-      "url": "https://react.dev",
-      "slug": "react"
+      "url": "https://react.dev"
     },
     {
       "name": "Tauri",
+      "slug": "tauri",
       "full_name": "tauri-apps/tauri",
       "description": "Build smaller, faster, and more secure desktop applications with a web frontend.",
       "stars": 74295,
@@ -134,11 +136,11 @@
       "owner_id": 54536011,
       "icon": "tauri.svg",
       "created_at": "2019-07-13T09:09:37.000Z",
-      "url": "https://tauri.app",
-      "slug": "tauri"
+      "url": "https://tauri.app"
     },
     {
       "name": "Drizzle ORM",
+      "slug": "drizzle-orm",
       "full_name": "drizzle-team/drizzle-orm",
       "description": "Headless TypeScript ORM with a head. Runs on Node, Bun and Deno. Lives on the Edge and yes, it's a JavaScript ORM too",
       "stars": 17143,
@@ -149,11 +151,11 @@
       "tags": ["orm", "sql"],
       "owner_id": 108468352,
       "created_at": "2021-06-24T09:03:05.000Z",
-      "url": "https://orm.drizzle.team",
-      "slug": "drizzle-orm"
+      "url": "https://orm.drizzle.team"
     },
     {
       "name": "htmx",
+      "slug": "htmx",
       "full_name": "bigskysoftware/htmx",
       "description": "Access AJAX, WebSockets and Server Sent Events directly in HTML",
       "stars": 29681,
@@ -165,11 +167,11 @@
       "owner_id": 48798027,
       "icon": "htmx.svg",
       "created_at": "2020-04-13T16:17:51.000Z",
-      "url": "https://htmx.org",
-      "slug": "htmx"
+      "url": "https://htmx.org"
     },
     {
       "name": "Astro",
+      "slug": "astro",
       "full_name": "withastro/astro",
       "description": "A website build tool for the modern web — powerful developer experience meets lightweight output.",
       "stars": 39802,
@@ -181,11 +183,11 @@
       "owner_id": 44914786,
       "icon": "astro.svg",
       "created_at": "2021-03-15T17:19:47.000Z",
-      "url": "https://astro.build",
-      "slug": "astro"
+      "url": "https://astro.build"
     },
     {
       "name": "VS Code",
+      "slug": "vs-code",
       "full_name": "microsoft/vscode",
       "description": "Visual Studio Code",
       "stars": 155847,
@@ -197,11 +199,11 @@
       "owner_id": 6154722,
       "icon": "vscode.svg",
       "created_at": "2015-09-03T20:23:38.000Z",
-      "url": "https://code.visualstudio.com",
-      "slug": "vs-code"
+      "url": "https://code.visualstudio.com"
     },
     {
       "name": "Zustand",
+      "slug": "zustand",
       "full_name": "pmndrs/zustand",
       "description": "Bear necessities for state management in React",
       "stars": 40058,
@@ -213,10 +215,11 @@
       "owner_id": 45790596,
       "created_at": "2019-04-09T09:10:06.000Z",
       "url": "https://zustand-demo.pmnd.rs/",
-      "slug": "zustand"
+      "icon": "zustand.webp"
     },
     {
       "name": "tRPC",
+      "slug": "trpc",
       "full_name": "trpc/trpc",
       "description": "Move Fast and Break Nothing. End-to-end typesafe APIs made easy.",
       "stars": 31580,
@@ -236,11 +239,11 @@
       "owner_id": 78011399,
       "icon": "trpc.svg",
       "created_at": "2020-07-18T01:17:11.000Z",
-      "url": "https://tRPC.io",
-      "slug": "trpc"
+      "url": "https://tRPC.io"
     },
     {
       "name": "draw-a-ui",
+      "slug": "draw-a-ui",
       "full_name": "SawyerHood/draw-a-ui",
       "description": "Draw a mockup and generate html for it",
       "stars": 12523,
@@ -262,11 +265,11 @@
       "tags": ["ml", "react", "tailwind"],
       "owner_id": 2380669,
       "created_at": "2023-11-07T05:47:49.000Z",
-      "url": "https://draw-a-ui.com",
-      "slug": "draw-a-ui"
+      "url": "https://draw-a-ui.com"
     },
     {
       "name": "Playwright",
+      "slug": "playwright",
       "full_name": "microsoft/playwright",
       "description": "A framework for Web Testing and Automation. It allows testing Chromium, Firefox and WebKit with a single API.",
       "stars": 59329,
@@ -276,11 +279,11 @@
       "owner_id": 6154722,
       "icon": "playwright.svg",
       "created_at": "2019-11-15T18:32:42.000Z",
-      "url": "https://playwright.dev",
-      "slug": "playwright"
+      "url": "https://playwright.dev"
     },
     {
       "name": "DaisyUI",
+      "slug": "daisyui",
       "full_name": "saadeghi/daisyui",
       "description": "Component classes to Tailwind CSS",
       "stars": 29059,
@@ -292,11 +295,11 @@
       "owner_id": 7342023,
       "icon": "daisy.svg",
       "created_at": "2020-11-28T22:57:27.000Z",
-      "url": "https://daisyui.com",
-      "slug": "daisyui"
+      "url": "https://daisyui.com"
     },
     {
       "name": "Zod",
+      "slug": "zod",
       "full_name": "colinhacks/zod",
       "description": "TypeScript-first schema validation with static type inference",
       "stars": 28767,
@@ -308,11 +311,11 @@
       "owner_id": 3084745,
       "icon": "zod.svg",
       "created_at": "2020-03-07T20:59:08.000Z",
-      "url": "https://zod.dev",
-      "slug": "zod"
+      "url": "https://zod.dev"
     },
     {
       "name": "Mermaid",
+      "slug": "mermaid",
       "full_name": "mermaid-js/mermaid",
       "description": "Generation of diagrams like flowcharts or sequence diagrams from text in a similar manner as markdown",
       "stars": 65021,
@@ -323,11 +326,11 @@
       "tags": ["chart", "d3", "diagram"],
       "owner_id": 57169982,
       "created_at": "2014-11-01T23:52:32.000Z",
-      "url": "https://mermaid.js.org",
-      "slug": "mermaid"
+      "url": "https://mermaid.js.org"
     },
     {
       "name": "Tailwind CSS",
+      "slug": "tailwind-css",
       "full_name": "tailwindlabs/tailwindcss",
       "description": "A utility-first CSS framework for rapid UI development.",
       "stars": 76074,
@@ -339,11 +342,11 @@
       "owner_id": 67109815,
       "icon": "tailwindcss.svg",
       "created_at": "2017-10-06T14:59:14.000Z",
-      "url": "https://tailwindcss.com/",
-      "slug": "tailwind-css"
+      "url": "https://tailwindcss.com/"
     },
     {
       "name": "Tabby",
+      "slug": "tabby",
       "full_name": "Eugeny/tabby",
       "description": "A terminal for a more modern age",
       "stars": 53757,
@@ -353,11 +356,11 @@
       "owner_id": 161476,
       "icon": "tabby.svg",
       "created_at": "2016-12-23T09:06:10.000Z",
-      "url": "https://tabby.sh",
-      "slug": "tabby"
+      "url": "https://tabby.sh"
     },
     {
       "name": "Vite",
+      "slug": "vite",
       "full_name": "vitejs/vite",
       "description": "Next generation frontend tooling. It's fast!",
       "stars": 63215,
@@ -369,11 +372,11 @@
       "owner_id": 65625612,
       "icon": "vite.svg",
       "created_at": "2020-04-21T05:03:57.000Z",
-      "url": "http://vitejs.dev",
-      "slug": "vite"
+      "url": "http://vitejs.dev"
     },
     {
       "name": "Refine",
+      "slug": "refine",
       "full_name": "refinedev/refine",
       "description": "A React Framework for building  internal tools, admin panels, dashboards & B2B apps with unmatched flexibility.",
       "stars": 21553,
@@ -385,10 +388,11 @@
       "owner_id": 104967037,
       "created_at": "2021-01-20T12:01:32.000Z",
       "url": "https://refine.dev",
-      "slug": "refine"
+      "icon": "refine.svg"
     },
     {
       "name": "Svelte",
+      "slug": "svelte",
       "full_name": "sveltejs/svelte",
       "description": "Cybernetically enhanced web apps",
       "stars": 75390,
@@ -398,11 +402,11 @@
       "owner_id": 23617963,
       "icon": "svelte.svg",
       "created_at": "2016-11-20T18:13:05.000Z",
-      "url": "https://svelte.dev",
-      "slug": "svelte"
+      "url": "https://svelte.dev"
     },
     {
       "name": "Docusaurus",
+      "slug": "docusaurus",
       "full_name": "facebook/docusaurus",
       "description": "Easy to maintain open source documentation websites.",
       "stars": 51242,
@@ -412,11 +416,11 @@
       "owner_id": 69631,
       "icon": "docusaurus.svg",
       "created_at": "2017-06-20T16:13:53.000Z",
-      "url": "https://docusaurus.io",
-      "slug": "docusaurus"
+      "url": "https://docusaurus.io"
     },
     {
       "name": "LangChain.js",
+      "slug": "langchainjs",
       "full_name": "langchain-ai/langchainjs",
       "description": " Building applications with LLMs through composability",
       "stars": 9960,
@@ -438,11 +442,11 @@
       "tags": ["ml"],
       "owner_id": 126733545,
       "created_at": "2023-02-06T22:50:27.000Z",
-      "url": "https://js.langchain.com/docs/",
-      "slug": "langchainjs"
+      "url": "https://js.langchain.com/docs/"
     },
     {
       "name": "create-t3-app",
+      "slug": "create-t3-app",
       "full_name": "t3-oss/create-t3-app",
       "description": "The best way to start a full-stack, typesafe Next.js app",
       "stars": 22350,
@@ -460,11 +464,11 @@
       ],
       "owner_id": 108266839,
       "created_at": "2022-05-24T13:31:01.000Z",
-      "url": "https://create.t3.gg",
-      "slug": "create-t3-app"
+      "url": "https://create.t3.gg"
     },
     {
       "name": "n8n",
+      "slug": "n8n",
       "full_name": "n8n-io/n8n",
       "description": "Free and source-available fair-code licensed workflow automation tool. Easily automate tasks across different services.",
       "stars": 38485,
@@ -474,10 +478,11 @@
       "owner_id": 45487711,
       "created_at": "2019-06-22T09:24:21.000Z",
       "url": "https://n8n.io",
-      "slug": "n8n"
+      "icon": "n8n.svg"
     },
     {
       "name": "nvm",
+      "slug": "nvm",
       "full_name": "nvm-sh/nvm",
       "description": "Node Version Manager - POSIX-compliant bash script to manage multiple active node.js versions",
       "stars": 73746,
@@ -485,11 +490,11 @@
       "monthly": [706, 792, 741, 731, 752, 772, 760, 733, 755, 835, 767, 716],
       "tags": ["nvm"],
       "owner_id": 49963700,
-      "created_at": "2010-04-15T17:47:47.000Z",
-      "slug": "nvm"
+      "created_at": "2010-04-15T17:47:47.000Z"
     },
     {
       "name": "NextUI",
+      "slug": "nextui",
       "full_name": "nextui-org/nextui",
       "description": "Beautiful, fast and modern React UI library.",
       "stars": 18257,
@@ -498,11 +503,11 @@
       "tags": ["component", "react", "tailwind"],
       "owner_id": 86160567,
       "created_at": "2021-04-22T13:06:23.000Z",
-      "url": "https://nextui.org",
-      "slug": "nextui"
+      "url": "https://nextui.org"
     },
     {
       "name": "Three.js",
+      "slug": "threejs",
       "full_name": "mrdoob/three.js",
       "description": "JavaScript 3D Library.",
       "stars": 97418,
@@ -512,11 +517,11 @@
       "owner_id": 97088,
       "icon": "threejs.svg",
       "created_at": "2010-03-23T18:58:01.000Z",
-      "url": "https://threejs.org/",
-      "slug": "threejs"
+      "url": "https://threejs.org/"
     },
     {
       "name": "TypeScript",
+      "slug": "typescript",
       "full_name": "microsoft/TypeScript",
       "description": "A superset of JavaScript that compiles to clean JavaScript output.",
       "stars": 96679,
@@ -526,11 +531,11 @@
       "owner_id": 6154722,
       "icon": "typescript.svg",
       "created_at": "2014-06-17T15:28:39.000Z",
-      "url": "https://www.typescriptlang.org",
-      "slug": "typescript"
+      "url": "https://www.typescriptlang.org"
     },
     {
       "name": "Nest",
+      "slug": "nest",
       "full_name": "nestjs/nest",
       "description": "A progressive Node.js framework for building efficient, scalable, and enterprise-grade server-side applications with TypeScript/JavaScript",
       "stars": 62820,
@@ -540,11 +545,11 @@
       "owner_id": 28507035,
       "icon": "nest.svg",
       "created_at": "2017-02-04T20:12:52.000Z",
-      "url": "https://nestjs.com",
-      "slug": "nest"
+      "url": "https://nestjs.com"
     },
     {
       "name": "Tremor",
+      "slug": "tremor",
       "full_name": "tremorlabs/tremor",
       "description": "The React library to build dashboards fast.",
       "stars": 14476,
@@ -553,11 +558,11 @@
       "tags": ["react", "dashboard", "tailwind"],
       "owner_id": 97241560,
       "created_at": "2022-04-19T20:54:32.000Z",
-      "url": "https://tremor.so",
-      "slug": "tremor"
+      "url": "https://tremor.so"
     },
     {
       "name": "Node.js",
+      "slug": "nodejs",
       "full_name": "nodejs/node",
       "description": "Node.js JavaScript runtime",
       "stars": 101799,
@@ -567,11 +572,11 @@
       "owner_id": 9950313,
       "icon": "nodejs.svg",
       "created_at": "2014-11-26T19:57:11.000Z",
-      "url": "https://nodejs.org",
-      "slug": "nodejs"
+      "url": "https://nodejs.org"
     },
     {
       "name": "Affine",
+      "slug": "affine",
       "full_name": "toeverything/AFFiNE",
       "description": "A next-gen knowledge base that brings planning, sorting and creating all together. Privacy first, open-source, customizable and ready to use - a free replacement for Notion & Miro",
       "stars": 26292,
@@ -594,10 +599,11 @@
       "owner_id": 78728988,
       "created_at": "2022-07-31T18:45:21.000Z",
       "url": "https://affine.pro",
-      "slug": "affine"
+      "icon": "affine.svg"
     },
     {
       "name": "Million",
+      "slug": "million",
       "full_name": "aidenybai/million",
       "description": "<1KB Virtual DOM Implementation",
       "stars": 14345,
@@ -607,8 +613,7 @@
       "owner_id": 38025074,
       "icon": "million.svg",
       "created_at": "2021-05-29T18:38:23.000Z",
-      "url": "https://million.dev",
-      "slug": "million"
+      "url": "https://million.dev"
     },
     {
       "name": "Serverless Stack",
@@ -625,6 +630,7 @@
     },
     {
       "name": "Vue.js",
+      "slug": "vuejs",
       "full_name": "vuejs/core",
       "description": "A progressive, incrementally-adoptable JavaScript framework for building UI on the web.",
       "stars": 43206,
@@ -634,11 +640,11 @@
       "owner_id": 6128107,
       "icon": "vue.svg",
       "created_at": "2018-06-12T13:49:36.000Z",
-      "url": "https://vuejs.org/",
-      "slug": "vuejs"
+      "url": "https://vuejs.org/"
     },
     {
       "name": "Nuxt",
+      "slug": "nuxt",
       "full_name": "nuxt/nuxt",
       "description": "The Intuitive Vue Framework.",
       "stars": 50410,
@@ -648,11 +654,11 @@
       "owner_id": 23360933,
       "icon": "nuxt.svg",
       "created_at": "2016-10-26T11:18:47.000Z",
-      "url": "https://nuxt.com",
-      "slug": "nuxt"
+      "url": "https://nuxt.com"
     },
     {
       "name": "Prisma",
+      "slug": "prisma",
       "full_name": "prisma/prisma",
       "description": "Next-generation ORM for Node.js & TypeScript | PostgreSQL, MySQL, MariaDB, SQL Server, SQLite, MongoDB and CockroachDB",
       "stars": 36171,
@@ -662,11 +668,11 @@
       "owner_id": 17219288,
       "icon": "prisma.svg",
       "created_at": "2019-06-20T13:33:47.000Z",
-      "url": "https://www.prisma.io",
-      "slug": "prisma"
+      "url": "https://www.prisma.io"
     },
     {
       "name": "Payload",
+      "slug": "payload",
       "full_name": "payloadcms/payload",
       "description": "The best way to build a modern backend + admin UI. No black magic, all TypeScript, and fully open-source, Payload is both an app framework and a headless CMS.",
       "stars": 17447,
@@ -678,10 +684,11 @@
       "owner_id": 62968818,
       "created_at": "2021-01-05T18:49:45.000Z",
       "url": "https://payloadcms.com",
-      "slug": "payload"
+      "icon": "payload.svg"
     },
     {
       "name": "Angular",
+      "slug": "angular",
       "full_name": "angular/angular",
       "description": "Deliver web apps with confidence",
       "stars": 93516,
@@ -691,11 +698,11 @@
       "owner_id": 139426,
       "icon": "angular.svg",
       "created_at": "2014-09-18T16:12:01.000Z",
-      "url": "https://angular.dev",
-      "slug": "angular"
+      "url": "https://angular.dev"
     },
     {
       "name": "TypeChat",
+      "slug": "typechat",
       "full_name": "microsoft/TypeChat",
       "description": "TypeChat is a library that makes it easy to build natural language interfaces using types.",
       "stars": 7464,
@@ -717,11 +724,11 @@
       "tags": ["ml", "chat"],
       "owner_id": 6154722,
       "created_at": "2023-06-20T00:52:38.000Z",
-      "url": "https://microsoft.github.io/TypeChat/",
-      "slug": "typechat"
+      "url": "https://microsoft.github.io/TypeChat/"
     },
     {
       "name": "ts-reset",
+      "slug": "ts-reset",
       "full_name": "total-typescript/ts-reset",
       "description": "A 'CSS reset' for TypeScript, improving types for common JavaScript API's",
       "stars": 7378,
@@ -730,11 +737,11 @@
       "tags": ["types"],
       "owner_id": 107223871,
       "created_at": "2023-02-19T14:01:18.000Z",
-      "url": "https://www.totaltypescript.com/ts-reset",
-      "slug": "ts-reset"
+      "url": "https://www.totaltypescript.com/ts-reset"
     },
     {
       "name": "Strapi",
+      "slug": "strapi",
       "full_name": "strapi/strapi",
       "description": "The leading open-source headless CMS. It’s 100% JavaScript, fully customizable and developer-first.",
       "stars": 58795,
@@ -744,11 +751,11 @@
       "owner_id": 19872173,
       "icon": "strapi.svg",
       "created_at": "2015-09-30T15:34:48.000Z",
-      "url": "https://strapi.io",
-      "slug": "strapi"
+      "url": "https://strapi.io"
     },
     {
       "name": "NextAuth.js",
+      "slug": "nextauthjs",
       "full_name": "nextauthjs/next-auth",
       "description": "Authentication for the Web.",
       "stars": 21181,
@@ -757,11 +764,11 @@
       "tags": ["auth", "nextjs"],
       "owner_id": 67470890,
       "created_at": "2018-01-27T12:28:16.000Z",
-      "url": "https://authjs.dev",
-      "slug": "nextauthjs"
+      "url": "https://authjs.dev"
     },
     {
       "name": "Bruno",
+      "slug": "bruno",
       "full_name": "usebruno/bruno",
       "description": "Opensource IDE For Exploring and Testing Api's (lightweight alternative to postman/insomnia)",
       "stars": 11893,
@@ -784,11 +791,11 @@
       "owner_id": 114530840,
       "icon": "bruno.svg",
       "created_at": "2022-09-27T20:51:45.000Z",
-      "url": "https://www.usebruno.com/",
-      "slug": "bruno"
+      "url": "https://www.usebruno.com/"
     },
     {
       "name": "Biome",
+      "slug": "biome",
       "full_name": "biomejs/biome",
       "description": "A toolchain for web projects, aimed to provide functionalities to maintain them. Biome offers formatter and linter, usable via CLI and LSP.",
       "stars": 8620,
@@ -811,11 +818,11 @@
       "owner_id": 140182603,
       "icon": "biome.svg",
       "created_at": "2023-07-27T20:30:22.000Z",
-      "url": "https://biomejs.dev",
-      "slug": "biome"
+      "url": "https://biomejs.dev"
     },
     {
       "name": "Expo",
+      "slug": "expo",
       "full_name": "expo/expo",
       "description": "An open-source platform for making universal native apps with React. Expo runs on Android, iOS, and the web.",
       "stars": 26916,
@@ -825,11 +832,11 @@
       "owner_id": 12504344,
       "icon": "expo.svg",
       "created_at": "2016-08-15T17:14:25.000Z",
-      "url": "https://docs.expo.dev",
-      "slug": "expo"
+      "url": "https://docs.expo.dev"
     },
     {
       "name": "React Native",
+      "slug": "react-native",
       "full_name": "facebook/react-native",
       "description": "A framework for building native applications using React",
       "stars": 114276,
@@ -839,11 +846,11 @@
       "owner_id": 69631,
       "icon": "react-native.svg",
       "created_at": "2015-01-09T18:10:16.000Z",
-      "url": "https://reactnative.dev/",
-      "slug": "react-native"
+      "url": "https://reactnative.dev/"
     },
     {
       "name": "Stylex",
+      "slug": "stylex",
       "full_name": "facebook/stylex",
       "description": "The styling system for ambitious user interface",
       "stars": 7629,
@@ -866,11 +873,11 @@
       "owner_id": 69631,
       "icon": "stylex.svg",
       "created_at": "2022-12-08T06:38:09.000Z",
-      "url": "https://stylexjs.com",
-      "slug": "stylex"
+      "url": "https://stylexjs.com"
     },
     {
       "name": "Wasp",
+      "slug": "wasp",
       "full_name": "wasp-lang/wasp",
       "description": "The fastest way to develop full-stack web apps with React & Node.js.",
       "stars": 9472,
@@ -879,11 +886,11 @@
       "tags": ["compiler", "react", "rpc", "fullstack"],
       "owner_id": 55102317,
       "created_at": "2020-01-30T13:48:54.000Z",
-      "url": "https://wasp-lang.dev",
-      "slug": "wasp"
+      "url": "https://wasp-lang.dev"
     },
     {
       "name": "Wails",
+      "slug": "wails",
       "full_name": "wailsapp/wails",
       "description": "Build desktop applications using Go & Web Technologies",
       "stars": 20953,
@@ -892,11 +899,11 @@
       "tags": ["desktop"],
       "owner_id": 39746503,
       "created_at": "2018-12-15T23:14:06.000Z",
-      "url": "https://wails.io",
-      "slug": "wails"
+      "url": "https://wails.io"
     },
     {
       "name": "Oxc",
+      "slug": "oxc",
       "full_name": "oxc-project/oxc",
       "description": "A collection of JavaScript tools written in Rust.",
       "stars": 7688,
@@ -919,10 +926,11 @@
       "owner_id": 149946238,
       "created_at": "2023-02-09T05:46:51.000Z",
       "url": "https://oxc-project.github.io",
-      "slug": "oxc"
+      "icon": "oxc.svg"
     },
     {
       "name": "Rspack",
+      "slug": "rspack",
       "full_name": "web-infra-dev/rspack",
       "description": "A fast Rust-based web bundler",
       "stars": 6891,
@@ -932,10 +940,11 @@
       "owner_id": 87694465,
       "created_at": "2022-04-01T08:45:30.000Z",
       "url": "https://rspack.dev",
-      "slug": "rspack"
+      "icon": "rspack.svg"
     },
     {
       "name": "Material UI",
+      "slug": "material-ui",
       "full_name": "mui/material-ui",
       "description": " A robust, customizable, and accessible library of foundational and advanced components, enabling you to build your own design system and develop React applications faster",
       "stars": 90693,
@@ -945,11 +954,11 @@
       "owner_id": 33663932,
       "icon": "material-ui.svg",
       "created_at": "2014-08-18T19:11:54.000Z",
-      "url": "https://mui.com/material-ui/",
-      "slug": "material-ui"
+      "url": "https://mui.com/material-ui/"
     },
     {
       "name": "UnoCSS",
+      "slug": "unocss",
       "full_name": "unocss/unocss",
       "description": "The instant on-demand atomic CSS engine.",
       "stars": 14895,
@@ -959,11 +968,11 @@
       "owner_id": 93899228,
       "icon": "unocss.svg",
       "created_at": "2021-09-30T17:06:46.000Z",
-      "url": "https://unocss.dev",
-      "slug": "unocss"
+      "url": "https://unocss.dev"
     },
     {
       "name": "Mantine",
+      "slug": "mantine",
       "full_name": "mantinedev/mantine",
       "description": "A fully featured React components library",
       "stars": 23378,
@@ -973,11 +982,11 @@
       "owner_id": 79146003,
       "icon": "mantine.svg",
       "created_at": "2021-01-07T14:02:19.000Z",
-      "url": "https://mantine.dev",
-      "slug": "mantine"
+      "url": "https://mantine.dev"
     },
     {
       "name": "Radix",
+      "slug": "radix",
       "full_name": "radix-ui/primitives",
       "description": "Radix Primitives is an open-source UI component library for building high-quality, accessible design systems and web apps. Maintained by @workos.",
       "stars": 13426,
@@ -987,11 +996,11 @@
       "owner_id": 75042455,
       "icon": "radix.svg",
       "created_at": "2020-06-19T13:23:22.000Z",
-      "url": "https://radix-ui.com/primitives",
-      "slug": "radix"
+      "url": "https://radix-ui.com/primitives"
     },
     {
       "name": "TanStack Query",
+      "slug": "tanstack-query",
       "full_name": "TanStack/query",
       "description": "Powerful asynchronous state management, server-state utilities and data fetching for the web. TS/JS, React Query, Solid Query, Svelte Query and Vue Query.",
       "stars": 38450,
@@ -1000,11 +1009,11 @@
       "tags": ["data", "graphql", "caching", "react", "vue", "solid", "svelte"],
       "owner_id": 72518640,
       "created_at": "2019-09-10T19:23:58.000Z",
-      "url": "https://tanstack.com/query",
-      "slug": "tanstack-query"
+      "url": "https://tanstack.com/query"
     },
     {
       "name": "Storybook",
+      "slug": "storybook",
       "full_name": "storybookjs/storybook",
       "description": "A frontend workshop for building UI components and pages in isolation. Made for UI development, testing, and documentation.",
       "stars": 81816,
@@ -1014,11 +1023,11 @@
       "owner_id": 22632046,
       "icon": "storybook.svg",
       "created_at": "2016-03-18T04:23:44.000Z",
-      "url": "https://storybook.js.org",
-      "slug": "storybook"
+      "url": "https://storybook.js.org"
     },
     {
       "name": "Vercel AI SDK",
+      "slug": "vercel-ai-sdk",
       "full_name": "vercel/ai",
       "description": "Build AI-powered applications with React, Svelte, Vue, and Solid",
       "stars": 5853,
@@ -1040,11 +1049,11 @@
       "tags": ["ml", "api-wrapper", "nextjs", "svelte", "vue"],
       "owner_id": 14985020,
       "created_at": "2023-05-23T15:04:08.000Z",
-      "url": "https://sdk.vercel.ai/docs",
-      "slug": "vercel-ai-sdk"
+      "url": "https://sdk.vercel.ai/docs"
     },
     {
       "name": "Solid",
+      "slug": "solid",
       "full_name": "solidjs/solid",
       "description": "A declarative, efficient, and flexible JavaScript library for building user interfaces.",
       "stars": 30445,
@@ -1054,11 +1063,11 @@
       "owner_id": 79226042,
       "icon": "solid.svg",
       "created_at": "2018-04-24T16:36:27.000Z",
-      "url": "https://solidjs.com",
-      "slug": "solid"
+      "url": "https://solidjs.com"
     },
     {
       "name": "Turborepo",
+      "slug": "turborepo",
       "full_name": "vercel/turbo",
       "description": "Incremental bundler and build system optimized for JavaScript and TypeScript, written in Rust – including Turbopack and Turborepo.",
       "stars": 24179,
@@ -1068,11 +1077,11 @@
       "owner_id": 14985020,
       "icon": "turborepo.svg",
       "created_at": "2021-10-05T17:37:11.000Z",
-      "url": "https://turbo.build",
-      "slug": "turborepo"
+      "url": "https://turbo.build"
     },
     {
       "name": "Qwik",
+      "slug": "qwik",
       "full_name": "BuilderIO/qwik",
       "description": "Instant-loading web apps, without effort",
       "stars": 19781,
@@ -1082,11 +1091,11 @@
       "owner_id": 35700027,
       "icon": "qwik.svg",
       "created_at": "2021-05-19T15:33:32.000Z",
-      "url": "https://qwik.dev",
-      "slug": "qwik"
+      "url": "https://qwik.dev"
     },
     {
       "name": "Transformers.js",
+      "slug": "transformersjs",
       "full_name": "xenova/transformers.js",
       "description": "Run ML models in the browser",
       "stars": 5859,
@@ -1095,11 +1104,11 @@
       "tags": ["ml"],
       "owner_id": 26504141,
       "created_at": "2023-02-13T13:51:45.000Z",
-      "url": "https://huggingface.co/docs/transformers.js",
-      "slug": "transformersjs"
+      "url": "https://huggingface.co/docs/transformers.js"
     },
     {
       "name": "Slidev",
+      "slug": "slidev",
       "full_name": "slidevjs/slidev",
       "description": "Presentation Slides for Developers",
       "stars": 30078,
@@ -1109,11 +1118,11 @@
       "owner_id": 83095831,
       "icon": "slidev.svg",
       "created_at": "2021-04-24T01:25:23.000Z",
-      "url": "https://sli.dev",
-      "slug": "slidev"
+      "url": "https://sli.dev"
     },
     {
       "name": "Bootstrap",
+      "slug": "bootstrap",
       "full_name": "twbs/bootstrap",
       "description": "The most popular HTML, CSS, and JavaScript framework for developing responsive, mobile first projects on the web.",
       "stars": 166794,
@@ -1123,11 +1132,11 @@
       "owner_id": 2918581,
       "icon": "bootstrap.svg",
       "created_at": "2011-07-29T21:19:00.000Z",
-      "url": "https://getbootstrap.com",
-      "slug": "bootstrap"
+      "url": "https://getbootstrap.com"
     },
     {
       "name": "Directus",
+      "slug": "directus",
       "full_name": "directus/directus",
       "description": "A real-time API and App dashboard for managing SQL database content.",
       "stars": 24686,
@@ -1144,11 +1153,11 @@
       ],
       "owner_id": 15967950,
       "created_at": "2012-12-12T01:35:36.000Z",
-      "url": "https://directus.io",
-      "slug": "directus"
+      "url": "https://directus.io"
     },
     {
       "name": "Tamagui",
+      "slug": "tamagui",
       "full_name": "tamagui/tamagui",
       "description": "Universal UI kit and style system for React Native + Web - with an optimizing compiler",
       "stars": 9360,
@@ -1157,11 +1166,11 @@
       "tags": ["react-native", "css-in-js", "atomic-css", "component", "rsc"],
       "owner_id": 94025540,
       "created_at": "2020-10-16T21:19:51.000Z",
-      "url": "https://tamagui.dev",
-      "slug": "tamagui"
+      "url": "https://tamagui.dev"
     },
     {
       "name": "Electron",
+      "slug": "electron",
       "full_name": "electron/electron",
       "description": "Build cross-platform desktop apps with JavaScript, HTML, and CSS",
       "stars": 110576,
@@ -1171,11 +1180,11 @@
       "owner_id": 13409222,
       "icon": "electron.svg",
       "created_at": "2013-04-12T01:47:36.000Z",
-      "url": "https://electronjs.org",
-      "slug": "electron"
+      "url": "https://electronjs.org"
     },
     {
       "name": "Vue Element Admin",
+      "slug": "vue-element-admin",
       "full_name": "PanJiaChen/vue-element-admin",
       "description": "A magical vue admin",
       "stars": 85424,
@@ -1184,11 +1193,11 @@
       "tags": ["vue", "dashboard"],
       "owner_id": 8121621,
       "icon": "vueelementadmin.png",
-      "created_at": "2017-04-17T03:35:49.000Z",
-      "slug": "vue-element-admin"
+      "created_at": "2017-04-17T03:35:49.000Z"
     },
     {
       "name": "Nx",
+      "slug": "nx",
       "full_name": "nrwl/nx",
       "description": "Smart Monorepos · Fast CI",
       "stars": 21193,
@@ -1198,11 +1207,11 @@
       "owner_id": 23692104,
       "icon": "nx.svg",
       "created_at": "2017-08-11T18:50:23.000Z",
-      "url": "https://nx.dev",
-      "slug": "nx"
+      "url": "https://nx.dev"
     },
     {
       "name": "Nue",
+      "slug": "nue",
       "full_name": "nuejs/nue",
       "description": "The Content First Web Framework",
       "stars": 5128,
@@ -1224,11 +1233,11 @@
       "tags": ["framework"],
       "owner_id": 128560732,
       "created_at": "2023-09-13T00:18:50.000Z",
-      "url": "https://nuejs.org",
-      "slug": "nue"
+      "url": "https://nuejs.org"
     },
     {
       "name": "VueUse",
+      "slug": "vueuse",
       "full_name": "vueuse/vueuse",
       "description": "Collection of essential Vue Composition Utilities for Vue 2 and 3",
       "stars": 18152,
@@ -1237,11 +1246,11 @@
       "tags": ["vue", "util"],
       "owner_id": 77578415,
       "created_at": "2019-12-14T06:44:59.000Z",
-      "url": "https://vueuse.org",
-      "slug": "vueuse"
+      "url": "https://vueuse.org"
     },
     {
       "name": "Pico.css",
+      "slug": "picocss",
       "full_name": "picocss/pico",
       "description": "Minimal CSS Framework for semantic HTML",
       "stars": 11393,
@@ -1250,11 +1259,11 @@
       "tags": ["css-lib"],
       "owner_id": 57780293,
       "created_at": "2019-11-15T09:42:54.000Z",
-      "url": "https://picocss.com",
-      "slug": "picocss"
+      "url": "https://picocss.com"
     },
     {
       "name": "Remix",
+      "slug": "remix",
       "full_name": "remix-run/remix",
       "description": "Build Better Websites. Create modern, resilient user experiences with web fundamentals.",
       "stars": 26553,
@@ -1264,11 +1273,11 @@
       "owner_id": 64235328,
       "icon": "remix.svg",
       "created_at": "2020-10-26T19:57:28.000Z",
-      "url": "https://remix.run",
-      "slug": "remix"
+      "url": "https://remix.run"
     },
     {
       "name": "Jotai",
+      "slug": "jotai",
       "full_name": "pmndrs/jotai",
       "description": "Primitive and flexible state management for React",
       "stars": 16572,
@@ -1278,10 +1287,11 @@
       "owner_id": 45790596,
       "created_at": "2020-08-11T23:15:36.000Z",
       "url": "https://jotai.org",
-      "slug": "jotai"
+      "icon": "jotai.webp"
     },
     {
       "name": "Vue.js 2",
+      "slug": "vuejs-2",
       "full_name": "vuejs/vue",
       "description": "A progressive, incrementally-adoptable framework for building UI on the web",
       "stars": 206360,
@@ -1291,11 +1301,11 @@
       "owner_id": 6128107,
       "icon": "vue.svg",
       "created_at": "2013-07-29T03:24:51.000Z",
-      "url": "http://v2.vuejs.org",
-      "slug": "vuejs-2"
+      "url": "http://v2.vuejs.org"
     },
     {
       "name": "SvelteKit",
+      "slug": "sveltekit",
       "full_name": "sveltejs/kit",
       "description": "web development, streamlined",
       "stars": 17248,
@@ -1304,11 +1314,11 @@
       "tags": ["svelte", "fullstack", "nodejs-framework", "vite"],
       "owner_id": 23617963,
       "created_at": "2020-10-15T14:00:23.000Z",
-      "url": "https://kit.svelte.dev",
-      "slug": "sveltekit"
+      "url": "https://kit.svelte.dev"
     },
     {
       "name": "Nextra",
+      "slug": "nextra",
       "full_name": "shuding/nextra",
       "description": "Simple, powerful and flexible site generation framework with everything you love from Next.js.",
       "stars": 9950,
@@ -1318,11 +1328,11 @@
       "owner_id": 3676859,
       "icon": "nextra.svg",
       "created_at": "2020-06-15T16:39:34.000Z",
-      "url": "https://nextra.site",
-      "slug": "nextra"
+      "url": "https://nextra.site"
     },
     {
       "name": "Puppeteer",
+      "slug": "puppeteer",
       "full_name": "puppeteer/puppeteer",
       "description": "Node.js API for Chrome",
       "stars": 86111,
@@ -1332,11 +1342,11 @@
       "owner_id": 6906516,
       "icon": "puppeteer.svg",
       "created_at": "2017-05-09T22:16:13.000Z",
-      "url": "https://pptr.dev",
-      "slug": "puppeteer"
+      "url": "https://pptr.dev"
     },
     {
       "name": "Panda",
+      "slug": "panda",
       "full_name": "chakra-ui/panda",
       "description": "Universal, Type-Safe, CSS-in-JS Framework for Product Teams",
       "stars": 4312,
@@ -1359,11 +1369,11 @@
       "owner_id": 54212428,
       "icon": "panda.svg",
       "created_at": "2022-07-27T06:49:27.000Z",
-      "url": "https://panda-css.com",
-      "slug": "panda"
+      "url": "https://panda-css.com"
     },
     {
       "name": "Element Plus",
+      "slug": "element-plus",
       "full_name": "element-plus/element-plus",
       "description": "A Vue.js 3 UI Library made by Element team",
       "stars": 22530,
@@ -1372,11 +1382,11 @@
       "tags": ["component", "vue"],
       "owner_id": 68583457,
       "created_at": "2020-07-21T06:51:19.000Z",
-      "url": "https://element-plus.org",
-      "slug": "element-plus"
+      "url": "https://element-plus.org"
     },
     {
       "name": "swc",
+      "slug": "swc",
       "full_name": "swc-project/swc",
       "description": "A super-fast compiler written in rust",
       "stars": 29519,
@@ -1386,11 +1396,11 @@
       "owner_id": 26715726,
       "icon": "swc.svg",
       "created_at": "2017-12-22T11:40:14.000Z",
-      "url": "https://swc.rs",
-      "slug": "swc"
+      "url": "https://swc.rs"
     },
     {
       "name": "Amplication",
+      "slug": "amplication",
       "full_name": "amplication/amplication",
       "description": "Instantly generate quality Node.js resources",
       "stars": 13112,
@@ -1399,11 +1409,11 @@
       "tags": ["nodejs-framework", "fullstack", "react", "graphql"],
       "owner_id": 65107786,
       "created_at": "2020-05-10T19:41:49.000Z",
-      "url": "https://amplication.com",
-      "slug": "amplication"
+      "url": "https://amplication.com"
     },
     {
       "name": "Vitest",
+      "slug": "vitest",
       "full_name": "vitest-dev/vitest",
       "description": "Next generation testing framework powered by Vite.",
       "stars": 11288,
@@ -1413,11 +1423,11 @@
       "owner_id": 95747107,
       "icon": "vitest.svg",
       "created_at": "2021-12-03T19:19:49.000Z",
-      "url": "https://vitest.dev",
-      "slug": "vitest"
+      "url": "https://vitest.dev"
     },
     {
       "name": "Fastify",
+      "slug": "fastify",
       "full_name": "fastify/fastify",
       "description": "Fast and low overhead web framework, for Node.js",
       "stars": 29961,
@@ -1427,11 +1437,11 @@
       "owner_id": 24939410,
       "icon": "fastify.svg",
       "created_at": "2016-09-28T19:10:14.000Z",
-      "url": "https://www.fastify.dev",
-      "slug": "fastify"
+      "url": "https://www.fastify.dev"
     },
     {
       "name": "Yew",
+      "slug": "yew",
       "full_name": "yewstack/yew",
       "description": "Rust / Wasm framework for creating reliable and efficient web applications",
       "stars": 29481,
@@ -1440,11 +1450,11 @@
       "tags": ["webassembly", "framework", "rust"],
       "owner_id": 49116234,
       "created_at": "2017-12-16T14:19:02.000Z",
-      "url": "https://yew.rs",
-      "slug": "yew"
+      "url": "https://yew.rs"
     },
     {
       "name": "Cypress",
+      "slug": "cypress",
       "full_name": "cypress-io/cypress",
       "description": "Fast, easy and reliable testing for anything that runs in a browser.",
       "stars": 45797,
@@ -1454,11 +1464,11 @@
       "owner_id": 8908513,
       "icon": "cypress.svg",
       "created_at": "2015-03-04T00:46:28.000Z",
-      "url": "https://cypress.io",
-      "slug": "cypress"
+      "url": "https://cypress.io"
     },
     {
       "name": "Lit",
+      "slug": "lit",
       "full_name": "lit/lit",
       "description": "A simple library for building fast, lightweight web components",
       "stars": 17084,
@@ -1468,11 +1478,11 @@
       "owner_id": 18489846,
       "icon": "lit.svg",
       "created_at": "2017-06-29T16:27:16.000Z",
-      "url": "https://lit.dev",
-      "slug": "lit"
+      "url": "https://lit.dev"
     },
     {
       "name": "VitePress",
+      "slug": "vitepress",
       "full_name": "vuejs/vitepress",
       "description": "Vite & Vue powered static site generator.",
       "stars": 10167,
@@ -1481,11 +1491,11 @@
       "tags": ["ssg", "vue", "vite"],
       "owner_id": 6128107,
       "created_at": "2020-04-30T23:16:17.000Z",
-      "url": "https://vitepress.dev",
-      "slug": "vitepress"
+      "url": "https://vitepress.dev"
     },
     {
       "name": "XState",
+      "slug": "xstate",
       "full_name": "statelyai/xstate",
       "description": "Actor-based state management & orchestration for complex app logic.",
       "stars": 25742,
@@ -1495,11 +1505,11 @@
       "owner_id": 61783956,
       "icon": "xstate.svg",
       "created_at": "2015-09-14T15:04:15.000Z",
-      "url": "https://stately.ai/docs",
-      "slug": "xstate"
+      "url": "https://stately.ai/docs"
     },
     {
       "name": "Alpine.js",
+      "slug": "alpinejs",
       "full_name": "alpinejs/alpine",
       "description": "A rugged, minimal framework for composing JavaScript behavior in your markup.",
       "stars": 26203,
@@ -1509,11 +1519,11 @@
       "owner_id": 59030169,
       "icon": "alpine.svg",
       "created_at": "2019-11-28T13:51:55.000Z",
-      "url": "https://alpinejs.dev",
-      "slug": "alpinejs"
+      "url": "https://alpinejs.dev"
     },
     {
       "name": "Tesseract.js",
+      "slug": "tesseractjs",
       "full_name": "naptha/tesseract.js",
       "description": "Pure Javascript OCR for more than 100 Languages",
       "stars": 32656,
@@ -1522,11 +1532,11 @@
       "tags": ["image", "ml", "webassembly"],
       "owner_id": 7720173,
       "created_at": "2015-06-24T02:49:52.000Z",
-      "url": "http://tesseract.projectnaptha.com/",
-      "slug": "tesseractjs"
+      "url": "http://tesseract.projectnaptha.com/"
     },
     {
       "name": "Express",
+      "slug": "express",
       "full_name": "expressjs/express",
       "description": "Fast, unopinionated, minimalist web framework for node.",
       "stars": 63061,
@@ -1536,11 +1546,11 @@
       "owner_id": 5658226,
       "icon": "express.svg",
       "created_at": "2009-06-26T18:56:01.000Z",
-      "url": "https://expressjs.com",
-      "slug": "express"
+      "url": "https://expressjs.com"
     },
     {
       "name": "tsup",
+      "slug": "tsup",
       "full_name": "egoist/tsup",
       "description": "The simplest and fastest way to bundle your TypeScript libraries.",
       "stars": 7611,
@@ -1549,11 +1559,11 @@
       "tags": ["build", "module"],
       "owner_id": 8784712,
       "created_at": "2020-03-19T16:23:41.000Z",
-      "url": "https://tsup.egoist.dev",
-      "slug": "tsup"
+      "url": "https://tsup.egoist.dev"
     },
     {
       "name": "Naive UI",
+      "slug": "naive-ui",
       "full_name": "tusen-ai/naive-ui",
       "description": "A Vue 3 Component Library. Fairly Complete. Theme Customizable. Uses TypeScript. Fast.",
       "stars": 14713,
@@ -1563,11 +1573,11 @@
       "owner_id": 109735111,
       "icon": "naiveui.svg",
       "created_at": "2021-06-04T13:47:28.000Z",
-      "url": "https://www.naiveui.com",
-      "slug": "naive-ui"
+      "url": "https://www.naiveui.com"
     },
     {
       "name": "VanJS",
+      "slug": "vanjs",
       "full_name": "vanjs-org/van",
       "description": "An ultra-lightweight, zero-dependency and unopinionated Reactive UI framework based on pure vanilla JavaScript and DOM",
       "stars": 3277,
@@ -1576,11 +1586,11 @@
       "tags": ["framework", "reactive"],
       "owner_id": 132869025,
       "created_at": "2023-05-08T05:45:31.000Z",
-      "url": "https://vanjs.org",
-      "slug": "vanjs"
+      "url": "https://vanjs.org"
     },
     {
       "name": "Selenium",
+      "slug": "selenium",
       "full_name": "SeleniumHQ/selenium",
       "description": "A browser automation framework and ecosystem.",
       "stars": 28786,
@@ -1589,11 +1599,11 @@
       "tags": ["test", "auto"],
       "owner_id": 983927,
       "created_at": "2013-01-14T21:40:56.000Z",
-      "url": "https://selenium.dev",
-      "slug": "selenium"
+      "url": "https://selenium.dev"
     },
     {
       "name": "Mock Service Worker",
+      "slug": "mock-service-worker",
       "full_name": "mswjs/msw",
       "description": "Seamless REST/GraphQL API mocking library for browser and Node.js.",
       "stars": 14381,
@@ -1602,11 +1612,11 @@
       "tags": ["test", "serviceworker"],
       "owner_id": 64637271,
       "created_at": "2018-11-13T14:58:44.000Z",
-      "url": "https://mswjs.io",
-      "slug": "mock-service-worker"
+      "url": "https://mswjs.io"
     },
     {
       "name": "PrimeVue",
+      "slug": "primevue",
       "full_name": "primefaces/primevue",
       "description": "Next Generation Vue UI Component Library",
       "stars": 6604,
@@ -1615,11 +1625,11 @@
       "tags": ["component", "vue"],
       "owner_id": 3494069,
       "created_at": "2018-12-04T07:04:14.000Z",
-      "url": "https://primevue.org",
-      "slug": "primevue"
+      "url": "https://primevue.org"
     },
     {
       "name": "Starlight",
+      "slug": "starlight",
       "full_name": "withastro/starlight",
       "description": "Build beautiful, accessible, high-performance documentation websites with Astro",
       "stars": 3046,
@@ -1641,11 +1651,11 @@
       "tags": ["ssg", "astro", "doc"],
       "owner_id": 44914786,
       "created_at": "2023-03-16T15:55:33.000Z",
-      "url": "https://starlight.astro.build",
-      "slug": "starlight"
+      "url": "https://starlight.astro.build"
     },
     {
       "name": "rrweb",
+      "slug": "rrweb",
       "full_name": "rrweb-io/rrweb",
       "description": "record and replay the web",
       "stars": 15169,
@@ -1654,11 +1664,11 @@
       "tags": ["debug", "auto"],
       "owner_id": 43396833,
       "created_at": "2018-10-06T13:35:55.000Z",
-      "url": "https://www.rrweb.io/",
-      "slug": "rrweb"
+      "url": "https://www.rrweb.io/"
     },
     {
       "name": "Vuetify",
+      "slug": "vuetify",
       "full_name": "vuetifyjs/vuetify",
       "description": "Vue Component Framework",
       "stars": 38714,
@@ -1668,11 +1678,11 @@
       "owner_id": 22138497,
       "icon": "vuetify.svg",
       "created_at": "2016-09-12T00:39:35.000Z",
-      "url": "https://vuetifyjs.com",
-      "slug": "vuetify"
+      "url": "https://vuetifyjs.com"
     },
     {
       "name": "esbuild",
+      "slug": "esbuild",
       "full_name": "evanw/esbuild",
       "description": "An extremely fast bundler for the web",
       "stars": 36792,
@@ -1682,11 +1692,11 @@
       "owner_id": 406394,
       "icon": "esbuild.svg",
       "created_at": "2016-06-14T16:08:50.000Z",
-      "url": "https://esbuild.github.io/",
-      "slug": "esbuild"
+      "url": "https://esbuild.github.io/"
     },
     {
       "name": "Pinia",
+      "slug": "pinia",
       "full_name": "vuejs/pinia",
       "description": "Intuitive, type safe, light and flexible Store for Vue using the composition api with DevTools support",
       "stars": 11996,
@@ -1696,11 +1706,11 @@
       "owner_id": 6128107,
       "icon": "pinia.svg",
       "created_at": "2019-11-18T21:05:01.000Z",
-      "url": "https://pinia.vuejs.org",
-      "slug": "pinia"
+      "url": "https://pinia.vuejs.org"
     },
     {
       "name": "Eleventy",
+      "slug": "eleventy",
       "full_name": "11ty/eleventy",
       "description": "A simpler site generator. Transforms a directory of templates (of varying types) into HTML.",
       "stars": 15814,
@@ -1709,11 +1719,11 @@
       "tags": ["ssg"],
       "owner_id": 35147177,
       "created_at": "2017-11-27T05:19:00.000Z",
-      "url": "https://www.11ty.dev/",
-      "slug": "eleventy"
+      "url": "https://www.11ty.dev/"
     },
     {
       "name": "Jest",
+      "slug": "jest",
       "full_name": "jestjs/jest",
       "description": "Delightful JavaScript Testing.",
       "stars": 43315,
@@ -1723,11 +1733,11 @@
       "owner_id": 103283236,
       "icon": "jest.svg",
       "created_at": "2013-12-10T00:18:04.000Z",
-      "url": "https://jestjs.io",
-      "slug": "jest"
+      "url": "https://jestjs.io"
     },
     {
       "name": "Quasar",
+      "slug": "quasar",
       "full_name": "quasarframework/quasar",
       "description": "Responsive Single Page Apps, Server-side Render Apps, Progressive Web Apps, Hybrid Mobile Apps (that look native!) & Electron Apps, all using the same codebase.",
       "stars": 24937,
@@ -1737,11 +1747,11 @@
       "owner_id": 23064371,
       "icon": "quasar.svg",
       "created_at": "2015-10-05T15:45:36.000Z",
-      "url": "https://quasar.dev",
-      "slug": "quasar"
+      "url": "https://quasar.dev"
     },
     {
       "name": "Preact",
+      "slug": "preact",
       "full_name": "preactjs/preact",
       "description": "Fast 3kB React alternative with the same modern API. Components & Virtual DOM.",
       "stars": 35759,
@@ -1751,11 +1761,11 @@
       "owner_id": 26872990,
       "icon": "preact.svg",
       "created_at": "2015-09-11T02:40:18.000Z",
-      "url": "https://preactjs.com",
-      "slug": "preact"
+      "url": "https://preactjs.com"
     },
     {
       "name": "Capacitor",
+      "slug": "capacitor",
       "full_name": "ionic-team/capacitor",
       "description": "Build cross-platform Native Progressive Web Apps for iOS, Android, and the Web",
       "stars": 10791,
@@ -1764,11 +1774,11 @@
       "tags": ["mobile"],
       "owner_id": 3171503,
       "created_at": "2017-11-18T21:38:09.000Z",
-      "url": "https://capacitorjs.com",
-      "slug": "capacitor"
+      "url": "https://capacitorjs.com"
     },
     {
       "name": "Nano stores",
+      "slug": "nano-stores",
       "full_name": "nanostores/nanostores",
       "description": "A tiny (298 bytes) state manager for React/RN/Preact/Vue/Svelte with many atomic tree-shakable stores",
       "stars": 4485,
@@ -1776,11 +1786,11 @@
       "monthly": [148, 155, 142, 163, 79, 132, 149, 138, 153, 165, 291, 278],
       "tags": ["state"],
       "owner_id": 85066968,
-      "created_at": "2020-10-14T19:51:28.000Z",
-      "slug": "nano-stores"
+      "created_at": "2020-10-14T19:51:28.000Z"
     },
     {
       "name": "Hexo",
+      "slug": "hexo",
       "full_name": "hexojs/hexo",
       "description": "A fast, simple & powerful blog framework, powered by Node.js.",
       "stars": 38097,
@@ -1790,11 +1800,11 @@
       "owner_id": 6375567,
       "icon": "hexo.svg",
       "created_at": "2012-09-23T15:17:08.000Z",
-      "url": "https://hexo.io",
-      "slug": "hexo"
+      "url": "https://hexo.io"
     },
     {
       "name": "Nativefier",
+      "slug": "nativefier",
       "full_name": "nativefier/nativefier",
       "description": "Make any web page a desktop application",
       "stars": 34543,
@@ -1802,11 +1812,11 @@
       "monthly": [48, 58, 55, 160, 168, 160, 167, 219, 178, 278, 233, 247],
       "tags": ["desktop"],
       "owner_id": 69503009,
-      "created_at": "2015-07-05T05:56:42.000Z",
-      "slug": "nativefier"
+      "created_at": "2015-07-05T05:56:42.000Z"
     },
     {
       "name": "NativeWind",
+      "slug": "nativewind",
       "full_name": "marklawlor/nativewind",
       "description": "React Native utility-first universal design system - powered by Tailwind CSS",
       "stars": 3765,
@@ -1815,11 +1825,11 @@
       "tags": ["react-native", "component", "tailwind", "css-in-js"],
       "owner_id": 3946701,
       "created_at": "2022-04-02T12:30:41.000Z",
-      "url": "https://nativewind.dev",
-      "slug": "nativewind"
+      "url": "https://nativewind.dev"
     },
     {
       "name": "vanilla-extract",
+      "slug": "vanilla-extract",
       "full_name": "vanilla-extract-css/vanilla-extract",
       "description": "Zero-runtime Stylesheets-in-TypeScript",
       "stars": 9108,
@@ -1829,11 +1839,11 @@
       "owner_id": 112610040,
       "icon": "vanilla.svg",
       "created_at": "2021-03-26T05:10:54.000Z",
-      "url": "https://vanilla-extract.style",
-      "slug": "vanilla-extract"
+      "url": "https://vanilla-extract.style"
     },
     {
       "name": "Valtio",
+      "slug": "valtio",
       "full_name": "pmndrs/valtio",
       "description": "Valtio makes proxy-state simple  for React and Vanilla",
       "stars": 8128,
@@ -1842,11 +1852,11 @@
       "tags": ["state", "react"],
       "owner_id": 45790596,
       "created_at": "2020-11-16T22:30:51.000Z",
-      "url": "http://valtio.pmnd.rs",
-      "slug": "valtio"
+      "url": "http://valtio.pmnd.rs"
     },
     {
       "name": "Nhost",
+      "slug": "nhost",
       "full_name": "nhost/nhost",
       "description": "The Open Source Firebase Alternative with GraphQL.",
       "stars": 7371,
@@ -1855,11 +1865,11 @@
       "tags": ["realtime", "websocket", "graphql", "serverless", "auth"],
       "owner_id": 48448799,
       "created_at": "2021-02-09T13:33:34.000Z",
-      "url": "https://nhost.io",
-      "slug": "nhost"
+      "url": "https://nhost.io"
     },
     {
       "name": "Styled Components",
+      "slug": "styled-components",
       "full_name": "styled-components/styled-components",
       "description": "Visual primitives for the component age. Use the best bits of ES6 and CSS to style your apps without stress",
       "stars": 39908,
@@ -1868,11 +1878,11 @@
       "tags": ["css-in-js"],
       "owner_id": 20658825,
       "created_at": "2016-08-16T06:41:32.000Z",
-      "url": "https://styled-components.com",
-      "slug": "styled-components"
+      "url": "https://styled-components.com"
     },
     {
       "name": "Gluon",
+      "slug": "gluon",
       "full_name": "gluon-framework/gluon",
       "description": "A new framework for creating desktop apps from websites, using system installed browsers and NodeJS",
       "stars": 3126,
@@ -1881,11 +1891,11 @@
       "tags": ["desktop"],
       "owner_id": 120422204,
       "created_at": "2022-12-07T16:07:54.000Z",
-      "url": "https://gluonjs.org",
-      "slug": "gluon"
+      "url": "https://gluonjs.org"
     },
     {
       "name": "Hasura GraphQL Engine",
+      "slug": "hasura-graphql-engine",
       "full_name": "hasura/graphql-engine",
       "description": "Blazing fast, instant realtime GraphQL APIs on your DB with fine grained access control, also trigger webhooks on database events.",
       "stars": 30678,
@@ -1895,11 +1905,11 @@
       "owner_id": 13966722,
       "icon": "hasura.svg",
       "created_at": "2018-06-18T07:57:36.000Z",
-      "url": "https://hasura.io",
-      "slug": "hasura-graphql-engine"
+      "url": "https://hasura.io"
     },
     {
       "name": "chatgpt.js",
+      "slug": "chatgptjs",
       "full_name": "KudoAI/chatgpt.js",
       "description": "A powerful, open source client-side JavaScript library for ChatGPT",
       "stars": 1706,
@@ -1921,11 +1931,11 @@
       "tags": ["ml", "chat"],
       "owner_id": 126222872,
       "created_at": "2023-03-15T07:53:55.000Z",
-      "url": "https://chatgpt.js.org",
-      "slug": "chatgptjs"
+      "url": "https://chatgpt.js.org"
     },
     {
       "name": "Signals",
+      "slug": "signals",
       "full_name": "preactjs/signals",
       "description": "Manage state with style in every framework",
       "stars": 3324,
@@ -1934,11 +1944,11 @@
       "tags": ["state", "react", "reactive"],
       "owner_id": 26872990,
       "created_at": "2022-08-08T21:29:28.000Z",
-      "url": "https://preactjs.com/blog/introducing-signals/",
-      "slug": "signals"
+      "url": "https://preactjs.com/blog/introducing-signals/"
     },
     {
       "name": "React Native Paper",
+      "slug": "react-native-paper",
       "full_name": "callstack/react-native-paper",
       "description": "Material Design for React Native (Android & iOS)",
       "stars": 11938,
@@ -1948,11 +1958,11 @@
       "owner_id": 42239399,
       "icon": "react-native-paper.svg",
       "created_at": "2016-10-19T05:56:53.000Z",
-      "url": "https://reactnativepaper.com",
-      "slug": "react-native-paper"
+      "url": "https://reactnativepaper.com"
     },
     {
       "name": "Ionic",
+      "slug": "ionic",
       "full_name": "ionic-team/ionic-framework",
       "description": "A powerful cross-platform UI toolkit for building native-quality iOS, Android, and Progressive Web Apps with HTML, CSS, and JavaScript.",
       "stars": 50160,
@@ -1962,11 +1972,11 @@
       "owner_id": 3171503,
       "icon": "ionic.svg",
       "created_at": "2013-08-20T23:06:02.000Z",
-      "url": "https://ionicframework.com",
-      "slug": "ionic"
+      "url": "https://ionicframework.com"
     },
     {
       "name": "Kuma UI",
+      "slug": "kuma-ui",
       "full_name": "kuma-ui/kuma-ui",
       "description": "A Headless, Utility-First, and Zero-Runtime UI Component Library",
       "stars": 1569,
@@ -1975,11 +1985,11 @@
       "tags": ["css-in-js", "react", "rsc"],
       "owner_id": 140625808,
       "created_at": "2023-03-30T18:49:41.000Z",
-      "url": "https://kuma-ui.com",
-      "slug": "kuma-ui"
+      "url": "https://kuma-ui.com"
     },
     {
       "name": "Ignite",
+      "slug": "ignite",
       "full_name": "infinitered/ignite",
       "description": "Battle-tested React Native boilerplate",
       "stars": 16303,
@@ -1987,11 +1997,11 @@
       "monthly": [106, 116, 134, 107, 101, 100, 119, 103, 162, 140, 142, 97],
       "tags": ["react-native", "boilerplate", "scaffolding"],
       "owner_id": 3902527,
-      "created_at": "2016-02-10T16:06:07.000Z",
-      "slug": "ignite"
+      "created_at": "2016-02-10T16:06:07.000Z"
     },
     {
       "name": "AI Emojis",
+      "slug": "ai-emojis",
       "full_name": "Pondorasti/emojis",
       "description": "Turn your ideas into emojis in seconds. Generate your favorite Slack emojis with just one click.",
       "stars": 1434,
@@ -2013,11 +2023,11 @@
       "tags": ["emoji", "ml"],
       "owner_id": 32957606,
       "created_at": "2023-09-24T22:55:42.000Z",
-      "url": "https://emojis.sh",
-      "slug": "ai-emojis"
+      "url": "https://emojis.sh"
     },
     {
       "name": "Legend-State",
+      "slug": "legend-state",
       "full_name": "LegendApp/legend-state",
       "description": " A super fast and powerful state manager for JavaScript apps",
       "stars": 2286,
@@ -2026,11 +2036,11 @@
       "tags": ["state", "react"],
       "owner_id": 60373862,
       "created_at": "2022-07-21T07:06:08.000Z",
-      "url": "https://legendapp.com/open-source/state/",
-      "slug": "legend-state"
+      "url": "https://legendapp.com/open-source/state/"
     },
     {
       "name": "Hermes",
+      "slug": "hermes",
       "full_name": "facebook/hermes",
       "description": " A small and lightweight JavaScript engine optimized for running React Native on Android",
       "stars": 9202,
@@ -2040,11 +2050,11 @@
       "owner_id": 69631,
       "icon": "hermes.svg",
       "created_at": "2018-10-22T19:13:00.000Z",
-      "url": "https://hermesengine.dev/",
-      "slug": "hermes"
+      "url": "https://hermesengine.dev/"
     },
     {
       "name": "jsdom",
+      "slug": "jsdom",
       "full_name": "jsdom/jsdom",
       "description": "A JavaScript implementation of various web standards, for use with Node.js",
       "stars": 19718,
@@ -2053,11 +2063,11 @@
       "tags": ["test"],
       "owner_id": 9271229,
       "icon": "jsdom.svg",
-      "created_at": "2010-01-19T06:55:19.000Z",
-      "slug": "jsdom"
+      "created_at": "2010-01-19T06:55:19.000Z"
     },
     {
       "name": "Garph",
+      "slug": "garph",
       "full_name": "stepci/garph",
       "description": "Fullstack GraphQL Framework for TypeScript",
       "stars": 1259,
@@ -2066,11 +2076,11 @@
       "tags": ["graphql", "data"],
       "owner_id": 61350067,
       "created_at": "2023-02-20T20:09:27.000Z",
-      "url": "https://garph.dev",
-      "slug": "garph"
+      "url": "https://garph.dev"
     },
     {
       "name": "Analog",
+      "slug": "analog",
       "full_name": "analogjs/analog",
       "description": "The fullstack meta-framework for Angular. Powered by Vite",
       "stars": 1964,
@@ -2079,11 +2089,11 @@
       "tags": ["angular", "ssg", "vite", "universal"],
       "owner_id": 96443982,
       "created_at": "2022-07-06T15:46:31.000Z",
-      "url": "https://analogjs.org",
-      "slug": "analog"
+      "url": "https://analogjs.org"
     },
     {
       "name": "face-api.js",
+      "slug": "face-apijs",
       "full_name": "justadudewhohacks/face-api.js",
       "description": "JavaScript API for face detection and face recognition in the browser and nodejs with tensorflow.js",
       "stars": 15899,
@@ -2091,11 +2101,11 @@
       "monthly": [91, 107, 92, 101, 76, 108, 145, 91, 101, 114, 106, 69],
       "tags": ["ml"],
       "owner_id": 31125521,
-      "created_at": "2018-05-19T06:14:53.000Z",
-      "slug": "face-apijs"
+      "created_at": "2018-05-19T06:14:53.000Z"
     },
     {
       "name": "TinyBase",
+      "slug": "tinybase",
       "full_name": "tinyplex/tinybase",
       "description": "The reactive data store for local‑first apps.",
       "stars": 2769,
@@ -2104,11 +2114,11 @@
       "tags": ["state", "table", "react"],
       "owner_id": 96894742,
       "created_at": "2021-12-31T01:06:00.000Z",
-      "url": "https://tinybase.org",
-      "slug": "tinybase"
+      "url": "https://tinybase.org"
     },
     {
       "name": "Bulma",
+      "slug": "bulma",
       "full_name": "jgthms/bulma",
       "description": "Modern CSS framework based on Flexbox",
       "stars": 47918,
@@ -2118,11 +2128,11 @@
       "owner_id": 1254808,
       "icon": "bulma.svg",
       "created_at": "2016-01-23T23:48:34.000Z",
-      "url": "https://bulma.io",
-      "slug": "bulma"
+      "url": "https://bulma.io"
     },
     {
       "name": "Redux",
+      "slug": "redux",
       "full_name": "reduxjs/redux",
       "description": "Predictable state container for JavaScript apps",
       "stars": 60262,
@@ -2132,11 +2142,11 @@
       "owner_id": 13142323,
       "icon": "redux.svg",
       "created_at": "2015-05-29T23:53:15.000Z",
-      "url": "https://redux.js.org",
-      "slug": "redux"
+      "url": "https://redux.js.org"
     },
     {
       "name": "Emotion",
+      "slug": "emotion",
       "full_name": "emotion-js/emotion",
       "description": "CSS-in-JS library designed for high performance style composition",
       "stars": 17048,
@@ -2145,11 +2155,11 @@
       "tags": ["css-in-js"],
       "owner_id": 31557565,
       "created_at": "2017-05-27T04:23:45.000Z",
-      "url": "https://emotion.sh/",
-      "slug": "emotion"
+      "url": "https://emotion.sh/"
     },
     {
       "name": "Redwood",
+      "slug": "redwood",
       "full_name": "redwoodjs/redwood",
       "description": "The App Framework for Startups",
       "stars": 16630,
@@ -2159,11 +2169,11 @@
       "owner_id": 45050444,
       "icon": "redwood.svg",
       "created_at": "2019-06-09T20:17:57.000Z",
-      "url": "https://redwoodjs.com",
-      "slug": "redwood"
+      "url": "https://redwoodjs.com"
     },
     {
       "name": "HuggingFace.js",
+      "slug": "huggingfacejs",
       "full_name": "huggingface/huggingface.js",
       "description": "Utilities to use the Hugging Face hub API",
       "stars": 1119,
@@ -2172,11 +2182,11 @@
       "tags": ["ml", "api-wrapper"],
       "owner_id": 25720743,
       "created_at": "2023-02-06T18:37:09.000Z",
-      "url": "https://hf.co/docs/huggingface.js",
-      "slug": "huggingfacejs"
+      "url": "https://hf.co/docs/huggingface.js"
     },
     {
       "name": "TensorFlow.js",
+      "slug": "tensorflowjs",
       "full_name": "tensorflow/tfjs",
       "description": "A WebGL accelerated JavaScript library for training and deploying ML models.",
       "stars": 17960,
@@ -2186,11 +2196,11 @@
       "owner_id": 15658638,
       "icon": "tensorflow.svg",
       "created_at": "2018-03-05T05:41:02.000Z",
-      "url": "https://js.tensorflow.org",
-      "slug": "tensorflowjs"
+      "url": "https://js.tensorflow.org"
     },
     {
       "name": "GraphiQL",
+      "slug": "graphiql",
       "full_name": "graphql/graphiql",
       "description": "GraphiQL & the GraphQL LSP Reference Ecosystem for building browser & IDE tools.",
       "stars": 15526,
@@ -2198,11 +2208,11 @@
       "monthly": [47, 55, 60, 87, 75, 73, 78, 86, 78, 104, 91, 110],
       "tags": ["graphql"],
       "owner_id": 12972006,
-      "created_at": "2015-08-11T02:56:22.000Z",
-      "slug": "graphiql"
+      "created_at": "2015-08-11T02:56:22.000Z"
     },
     {
       "name": "Gatsby",
+      "slug": "gatsby",
       "full_name": "gatsbyjs/gatsby",
       "description": "The best React-based framework with performance, scalability and security built in.",
       "stars": 54937,
@@ -2212,11 +2222,11 @@
       "owner_id": 12551863,
       "icon": "gatsby.svg",
       "created_at": "2015-05-21T22:43:05.000Z",
-      "url": "https://www.gatsbyjs.com",
-      "slug": "gatsby"
+      "url": "https://www.gatsbyjs.com"
     },
     {
       "name": "GraphQL Code Generator",
+      "slug": "graphql-code-generator",
       "full_name": "dotansimha/graphql-code-generator",
       "description": "A tool for generating code based on a GraphQL schema and GraphQL operations (query/mutation/subscription), with flexible support for custom plugins.",
       "stars": 10531,
@@ -2226,11 +2236,11 @@
       "owner_id": 3680083,
       "icon": "graphql-code-generator.svg",
       "created_at": "2016-12-05T19:15:11.000Z",
-      "url": "https://the-guild.dev/graphql/codegen/",
-      "slug": "graphql-code-generator"
+      "url": "https://the-guild.dev/graphql/codegen/"
     },
     {
       "name": "Primer",
+      "slug": "primer",
       "full_name": "primer/css",
       "description": "The CSS design system that powers GitHub",
       "stars": 12396,
@@ -2239,11 +2249,11 @@
       "tags": ["css-lib", "design-system"],
       "owner_id": 7143434,
       "created_at": "2015-03-19T23:31:21.000Z",
-      "url": "https://primer.style/css",
-      "slug": "primer"
+      "url": "https://primer.style/css"
     },
     {
       "name": "SemanticUI",
+      "slug": "semanticui",
       "full_name": "Semantic-Org/Semantic-UI",
       "description": "A UI component framework based around useful principles from natural language",
       "stars": 50936,
@@ -2253,11 +2263,11 @@
       "owner_id": 5796209,
       "icon": "semantic-ui.svg",
       "created_at": "2013-04-08T23:32:04.000Z",
-      "url": "http://www.semantic-ui.com",
-      "slug": "semanticui"
+      "url": "http://www.semantic-ui.com"
     },
     {
       "name": "PureCSS",
+      "slug": "purecss",
       "full_name": "pure-css/pure",
       "description": "A set of small, responsive CSS modules that you can use in every web project.",
       "stars": 23315,
@@ -2266,11 +2276,11 @@
       "tags": ["css-lib"],
       "owner_id": 23743443,
       "created_at": "2013-04-22T16:16:39.000Z",
-      "url": "http://purecss.io/",
-      "slug": "purecss"
+      "url": "http://purecss.io/"
     },
     {
       "name": "Windi CSS",
+      "slug": "windi-css",
       "full_name": "windicss/windicss",
       "description": "Next generation utility-first CSS framework.",
       "stars": 6488,
@@ -2279,11 +2289,11 @@
       "tags": ["css-lib", "tailwind", "atomic-css"],
       "owner_id": 79109951,
       "created_at": "2020-12-29T07:17:33.000Z",
-      "url": "https://windicss.org",
-      "slug": "windi-css"
+      "url": "https://windicss.org"
     },
     {
       "name": "Material Components",
+      "slug": "material-components",
       "full_name": "material-components/material-components-web",
       "description": "Modular and customizable Material Design UI components for the web",
       "stars": 17036,
@@ -2292,11 +2302,11 @@
       "tags": ["material", "css-lib"],
       "owner_id": 19478152,
       "created_at": "2016-12-05T16:04:09.000Z",
-      "url": "https://material.io/develop/web",
-      "slug": "material-components"
+      "url": "https://material.io/develop/web"
     },
     {
       "name": "Bootswatch",
+      "slug": "bootswatch",
       "full_name": "thomaspark/bootswatch",
       "description": "Themes for Bootstrap",
       "stars": 14377,
@@ -2305,8 +2315,7 @@
       "tags": ["css-lib", "bootstrap"],
       "owner_id": 900407,
       "created_at": "2012-02-07T04:31:56.000Z",
-      "url": "https://bootswatch.com",
-      "slug": "bootswatch"
+      "url": "https://bootswatch.com"
     }
   ],
   "tags": [

--- a/src/components/category-nav-by-year.astro
+++ b/src/components/category-nav-by-year.astro
@@ -15,7 +15,7 @@ const { language, year, category } = Astro.props;
 const years = await getAvailableYears();
 const index = years.indexOf(year);
 const previousYear = index > 0 ? years[index - 1] : null;
-const nextYear = index < year.length ? years[index + 1] : null;
+const nextYear = index < years.length - 1 ? years[index + 1] : null;
 const hasPreviousYear = previousYear !== null;
 const hasNextYear = nextYear !== null;
 


### PR DESCRIPTION
## Goal

- Fix condition to show "next" button after #143 
- Add project `icon` for data from 2016 ~ 2023 by running the script `cleanup-risingstars` from bestofjs-mono repo

## How to test

Check the "next" button shows up correctly when visittig data for the previous years

## Screenshots

![image](https://github.com/user-attachments/assets/8eb19322-84d6-4d4e-aefe-eb28e40eb3b6)

